### PR TITLE
Fix ranking for disconnected tags

### DIFF
--- a/padjective/ranking.py
+++ b/padjective/ranking.py
@@ -1,7 +1,7 @@
 import argparse
 import sqlite3
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 import choix
@@ -17,15 +17,75 @@ def load_pairs(db_path: Path) -> List[Tuple[str, str]]:
     return pairs
 
 
+def _connected_components(graph: Dict[str, List[str]]) -> List[List[str]]:
+    """Return connected components of an undirected graph."""
+    components: List[List[str]] = []
+    visited: set[str] = set()
+    for node in graph:
+        if node in visited:
+            continue
+        stack = [node]
+        comp: List[str] = []
+        visited.add(node)
+        while stack:
+            cur = stack.pop()
+            comp.append(cur)
+            for neighbor in graph[cur]:
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    stack.append(neighbor)
+        components.append(comp)
+    return components
+
+
+def _safe_ilsr(num_tags: int, data: List[Tuple[int, int]]) -> List[float]:
+    """Return ILSR scores, falling back to win ratios if necessary."""
+    if num_tags == 1:
+        return [0.0]
+    try:
+        return list(choix.ilsr_pairwise(num_tags, data))
+    except (ValueError, RuntimeError):
+        wins = [0] * num_tags
+        games = [0] * num_tags
+        for w, l in data:
+            wins[w] += 1
+            games[w] += 1
+            games[l] += 1
+        return [wins[i] / games[i] if games[i] else 0.0 for i in range(num_tags)]
+
+
 def compute_rankings(pairs: List[Tuple[str, str]]) -> pd.DataFrame:
-    """Return a DataFrame of tags ranked by skill."""
+    """Return a DataFrame of tags ranked by skill.
+
+    Handles disjoint sets of tags by ranking each connected component
+    separately.
+    """
+    if not pairs:
+        return pd.DataFrame(columns=["tag", "component", "score"])
+
     tags = sorted({t for pair in pairs for t in pair})
-    tag_to_id = {tag: i for i, tag in enumerate(tags)}
-    data = [(tag_to_id[w], tag_to_id[l]) for w, l in pairs]
-    # Bradley-Terry using iterative Luce spectral ranking
-    scores = choix.ilsr_pairwise(len(tags), data)
-    df = pd.DataFrame({"tag": tags, "score": scores})
-    return df.sort_values("score", ascending=False).reset_index(drop=True)
+
+    graph: Dict[str, List[str]] = {t: [] for t in tags}
+    for w, l in pairs:
+        graph[w].append(l)
+        graph[l].append(w)
+
+    components = _connected_components(graph)
+
+    records = []
+    for comp_id, comp_tags in enumerate(components):
+        tag_to_id = {tag: i for i, tag in enumerate(comp_tags)}
+        comp_pairs = [
+            (tag_to_id[w], tag_to_id[l])
+            for w, l in pairs
+            if w in tag_to_id and l in tag_to_id
+        ]
+        scores = _safe_ilsr(len(comp_tags), comp_pairs)
+        for tag, score in zip(comp_tags, scores):
+            records.append({"tag": tag, "component": comp_id, "score": float(score)})
+
+    df = pd.DataFrame(records)
+    return df.sort_values(["component", "score"], ascending=[True, False]).reset_index(drop=True)
 
 
 def save_rankings(df: pd.DataFrame, csv_path: Path) -> None:

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,12 @@
+from padjective.ranking import compute_rankings
+
+
+def test_compute_rankings_disjoint_components():
+    pairs = [("A", "B"), ("B", "C"), ("X", "Y")]
+    df = compute_rankings(pairs)
+    # Expect two components
+    assert sorted(df["component"].unique()) == [0, 1]
+    # Component 1 has single tag 'X' or 'Y', score 0
+    assert df[df["tag"] == "X"]["score"].iloc[0] == 0.0 or df[df["tag"] == "Y"]["score"].iloc[0] == 0.0
+    assert df.shape[0] == 5
+


### PR DESCRIPTION
## Summary
- handle multiple disconnected components in `ranking.compute_rankings`
- add fallback when choix ranking fails to converge
- add tests for ranking with disjoint tag components

## Testing
- `PYTHONPATH=. .venv/bin/pytest -q`