### PR TITLE
Restore README and migrate experiment notes to README2

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,31 @@
+# padjective
+
+Calculate p-adic adjective embeddings
+
+# Purpose
+
+Document and reproduce experiments that learn adjective ordering rules with p-adic techniques.
+
+# Current experiment: p-adic adjective embeddings
+
+## Motivation
+
+Across multiple projects we have noticed that when we train models with p-adic losses the learned coefficients almost always collapse onto pure powers of the prime \(p\). Even when starting from arbitrary integer weights the optimiser quickly drives them toward \(p^{b_n}\) with coefficient one. Mixed terms of the form \(a_n p^{b_n}\) with \(a_n \neq 1\) are rare in practice. We suspect there is a tropicalisation argument lurking here that would explain the collapse analytically.
+
+## Embedding strategies under test
+
+1. **Byte/character encodings.** Interpret the UTF-8 (or ASCII) byte sequence of a word directly as a p-adic expansion. Words that are 2-adically close therefore share suffixes, which aligns with how Indo-European inflectional endings behave. The hope is that grammatical shifts correspond to simple linear operations in this space.
+2. **Lexical hierarchy encodings.** Place each word inside a lightly pruned WordNet-like tree and turn the branch decisions into digits of the p-adic number. We and others have published variants of this approach. The embeddings themselves span a larger set of coefficients, yet downstream supervised learners still favour pure powers of \(p\).
+3. **Sequential encodings for adjective order.** Focus on sequences of adjectives that precede a noun. Each adjective receives a p-adic integer that is a single power of \(p\), encoding where the adjective tends to appear relative to its neighbours. This representation is agnostic to meaning but accurately predicts which adjective should come first or next—essentially mirroring the behaviour required of an autoregressive language model.
+
+## What works so far
+
+With these encodings in place we fit linear models using p-adic losses. Compared to brute-force p-adic linear regression the supervised optimisation converges much faster and achieves strong accuracy on held-out adjective sequences. The workflow demonstrates that we can efficiently learn ordering preferences without leaning on semantic information.
+
+## Open questions
+
+- Can we formalise why p-adic losses prefer pure powers via tropical geometry or another analytic argument?
+- How does training time compare against conventional (real-valued) optimisation baselines for the same tasks?
+- Which qualitative examples best illustrate the ordering predictions to a reader who is unfamiliar with p-adic methods?
+
+Answering those questions should make the experiment more compelling while keeping the focus on adjective ordering.

--- a/daily_results_site_ideas.md
+++ b/daily_results_site_ideas.md
@@ -1,0 +1,30 @@
+# Daily Tag Hierarchy Website Ideas
+
+The experiment already produces rich ranking artifacts (CSV, HTML, PNG) for the sampled Shopify catalog. A daily website that publishes fresh results as the full dataset is processed can turn those artifacts into an evolving story about tag relationships. Below are ideas for structuring that experience.
+
+## Hero Overview
+- **Daily headline numbers:** Surface the count of titles processed, distinct tags seen, and the number of tag "battles" recorded for the most recent ingest.
+- **Depth snapshot:** Show the current leaderboard of top tags by inferred depth with badges for notable movers compared to the prior day.
+- **Pipeline health indicator:** Include a simple status light or log excerpt summarizing whether tagbattle, ranking, and display stages ran successfully overnight.
+
+## Interactive Exploration
+- **Depth timeline charts:** Plot how individual tags move up or down in rank over time, with tooltips linking back to representative product titles.
+- **Component explorer:** Offer an interactive graph view (e.g., force-directed) for connected components discovered by `ranking.py`, highlighting which tags battle frequently.
+- **Search & compare:** Provide a search box to pull up a tag's history, see its typical co-occurring tags, and compare it against another tag's trend.
+
+## Daily Digest & Narrative
+- **Automated changelog:** Generate a narrative summary (e.g., "Tag X gained 3 spots, entering the top 20") based on significant Elo shifts.
+- **Anomaly callouts:** Flag tags with unusually large score swings or newly discovered relationships, potentially linking to the product titles that caused the change.
+- **Depth distribution histograms:** Visualize how many tags fall into each inferred depth bucket to detect structural shifts in the hierarchy.
+
+## Methodology & Transparency
+- **Pipeline explanation:** Reuse concise descriptions of `tagbattle.py`, `ranking.py`, and `display.py` so visitors understand how ranks are produced.
+- **Data freshness banner:** Note the timestamp of the dataset snapshot and clarify the sampling strategy versus the full corpus.
+- **Reproducibility corner:** Link to the Git repository, document commands (e.g., `uv run padjective/tagbattle.py`), and describe how to rerun analyses locally.
+
+## Engagement & Sharing
+- **Download center:** Offer the latest CSV/HTML/PNG artifacts for researchers to reuse, along with archived historical bundles.
+- **Newsletter signup:** Allow visitors to subscribe to a weekly recap summarizing the biggest shifts in tag hierarchy.
+- **API endpoint teaser:** If feasible, expose a lightweight JSON feed of the current rankings so others can build derivative analyses.
+
+These components combine daily operational transparency with deep exploratory tools, helping stakeholders watch the Shopify tag hierarchy evolve in near real time.


### PR DESCRIPTION
## Summary
- move the p-adic adjective experiment write-up into a new README2.md
- restore README.md to the original tag hierarchy pipeline instructions

## Testing
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d6627f1be88325bac9394e6f92acf1