### PR TITLE
Add hold-out evaluation pipeline and surface progress on site

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,24 @@ This will create ``battles.sqlite`` from ``products_point_one_percent_sample.csv
 produce ``tag_rankings.csv`` and render ``tag_rankings.html`` and
 ``tag_rankings.png``.
 
+## Hold-out experiments
+
+To monitor how well the inferred rankings predict unseen tag orderings, use the
+``padjective.experiments`` module. It manages a queue of randomised hold-out
+tasks and stores the outcomes in ``holdout_tasks.sqlite`` by default.
+
+```bash
+# create (or extend) a task queue of 5,000 random splits
+uv run -m padjective.experiments init --total 5000 --test-fraction 0.2
+
+# execute up to 250 pending tasks using an existing battles database
+uv run -m padjective.experiments run \
+    --database battles.sqlite \
+    --tasks-db holdout_tasks.sqlite \
+    --take 250
+
+# show overall progress and mean accuracy
+uv run -m padjective.experiments status --tasks-db holdout_tasks.sqlite
+```
+
     

--- a/cronscript.sh
+++ b/cronscript.sh
@@ -8,8 +8,18 @@ git pull -q
 
 CSV_PATH=${PADJECTIVE_PRODUCTS_CSV:-products_point_one_percent_sample.csv}
 OUTPUT_DIR=${PADJECTIVE_SITE_DIR:-build/site}
+TASKS_DB=${PADJECTIVE_TASKS_DB:-data/holdout_tasks.sqlite}
+TOTAL_TASKS=${PADJECTIVE_TOTAL_HOLDOUT_TASKS:-5000}
+TASK_BATCH=${PADJECTIVE_TASK_BATCH:-250}
+BATTLES_DB=${PADJECTIVE_BATTLES_DB:-build/battles.sqlite}
 
-uv run -m padjective.build_site --csv "$CSV_PATH" --output "$OUTPUT_DIR"
+mkdir -p "$(dirname "$TASKS_DB")"
+mkdir -p "$(dirname "$BATTLES_DB")"
+
+uv run padjective/tagbattle.py --csv "$CSV_PATH" --database "$BATTLES_DB"
+uv run -m padjective.experiments init --tasks-db "$TASKS_DB" --total "$TOTAL_TASKS"
+uv run -m padjective.experiments run --tasks-db "$TASKS_DB" --database "$BATTLES_DB" --take "$TASK_BATCH"
+uv run -m padjective.build_site --csv "$CSV_PATH" --output "$OUTPUT_DIR" --precomputed-database "$BATTLES_DB" --tasks-db "$TASKS_DB"
 
 REMOTE_SITE="padjective@merah.cassia.ifost.org.au:/var/www/vhosts/padjective.symmachus.org/htdocs/"
 rsync -avz --delete "$OUTPUT_DIR/" "$REMOTE_SITE"

--- a/padjective/build_site.py
+++ b/padjective/build_site.py
@@ -9,11 +9,11 @@ import shutil
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import pandas as pd
 
-from . import display, ranking, tagbattle
+from . import display, experiments, ranking, tagbattle
 
 
 def _ensure_clean_directory(path: Path) -> None:
@@ -65,6 +65,7 @@ def _build_index_html(
     chart_path: Path,
     artifact_links: Dict[str, Path],
     source_csv: Path,
+    experiments_summary: Optional[Dict[str, Any]] = None,
 ) -> None:
     top_table = leaderboard.head(20).to_html(index=False, classes="leaderboard")
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -73,6 +74,90 @@ def _build_index_html(
         f'<li><a href="{path.relative_to(output_dir).as_posix()}">{label}</a></li>'
         for label, path in artifact_links.items()
     )
+
+    experiments_block = ""
+    if experiments_summary and experiments_summary.get("total"):
+        counts = experiments_summary.get("counts", {})
+        completed = experiments_summary.get("completed_tasks", 0)
+        total = experiments_summary.get("total", 0)
+        mean_accuracy = experiments_summary.get("mean_accuracy")
+        mean_coverage = experiments_summary.get("mean_coverage")
+        recent_rows = experiments_summary.get("recent", [])
+
+        mean_accuracy_text = (
+            f"{mean_accuracy * 100:.2f}%" if mean_accuracy is not None else "n/a"
+        )
+        mean_coverage_text = (
+            f"{mean_coverage * 100:.2f}%" if mean_coverage is not None else "n/a"
+        )
+        test_fraction = experiments_summary.get("test_fraction") or 0.0
+
+        recent_items_list = []
+        for row in recent_rows:
+            accuracy_cell = (
+                f"<td>{row['accuracy'] * 100:.2f}%</td>"
+                if row.get("accuracy") is not None
+                else "<td>n/a</td>"
+            )
+            coverage_cell = (
+                f"<td>{row['coverage'] * 100:.2f}%</td>"
+                if row.get("coverage") is not None
+                else "<td>n/a</td>"
+            )
+            recent_items_list.append(
+                "<tr>"
+                f"<td>{row['id']}</td>"
+                f"<td>{row['seed']}</td>"
+                f"<td>{row['evaluated_pairs'] or 0}</td>"
+                f"{accuracy_cell}"
+                f"{coverage_cell}"
+                f"<td>{row['completed_at'] or ''}</td>"
+                "</tr>"
+            )
+        recent_items = "\n".join(recent_items_list)
+        if not recent_items:
+            recent_items = "<tr><td colspan=\"6\">No completed evaluations yet.</td></tr>"
+
+        experiments_block = f"""
+  <section class=\"experiments\">
+    <h2>Hold-out experiments</h2>
+    <p>We randomly reserve {test_fraction:.0%} of recorded tag battles and check whether the rankings predict the correct ordering.</p>
+    <div class=\"experiments-metrics\">
+      <div class=\"metric\">
+        <span class=\"value\">{completed:,} / {total:,}</span>
+        <span class=\"label\">Tasks completed</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{counts.get('pending', 0):,}</span>
+        <span class=\"label\">Pending tasks</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{counts.get('running', 0):,}</span>
+        <span class=\"label\">Running tasks</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{counts.get('error', 0):,}</span>
+        <span class=\"label\">Errors</span>
+      </div>
+    </div>
+    <p class=\"experiments-accuracy\">Average accuracy across completed tasks: {mean_accuracy_text} (coverage {mean_coverage_text}).</p>
+    <table class=\"experiments-table\">
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th>Seed</th>
+          <th>Evaluated battles</th>
+          <th>Accuracy</th>
+          <th>Coverage</th>
+          <th>Completed</th>
+        </tr>
+      </thead>
+      <tbody>
+        {recent_items}
+      </tbody>
+    </table>
+  </section>
+"""
 
     html = f"""<!DOCTYPE html>
 <html lang=\"en\">
@@ -135,6 +220,8 @@ def _build_index_html(
     <p>Historical SQL dumps are synchronised to <a href=\"https://datadumps.ifost.org.au/padjective/\">datadumps.ifost.org.au</a>.</p>
   </section>
 
+  {experiments_block}
+
   <footer>
     <p>Built from <code>{source_csv.name}</code>. Source available on <a href=\"https://github.com/IFost-Sydney-Uni/padjective\">GitHub</a>.</p>
   </footer>
@@ -145,7 +232,13 @@ def _build_index_html(
     (output_dir / "index.html").write_text(html, encoding="utf-8")
 
 
-def build_site(csv_path: Path, output_dir: Path) -> Dict[str, Any]:
+def build_site(
+    csv_path: Path,
+    output_dir: Path,
+    *,
+    precomputed_database: Optional[Path] = None,
+    tasks_db: Optional[Path] = None,
+) -> Dict[str, Any]:
     csv_path = csv_path.resolve()
     _ensure_clean_directory(output_dir)
 
@@ -156,10 +249,22 @@ def build_site(csv_path: Path, output_dir: Path) -> Dict[str, Any]:
         path.mkdir(parents=True, exist_ok=True)
 
     db_path = downloads_dir / "battles.sqlite"
-    if db_path.exists():
-        db_path.unlink()
 
-    tagbattle.process_csv(csv_path, db_path)
+    if precomputed_database is not None:
+        source = precomputed_database.resolve()
+        destination = db_path.resolve()
+        if source != destination:
+            if db_path.exists():
+                db_path.unlink()
+            shutil.copyfile(source, db_path)
+        else:
+            # The precomputed database already matches the expected output path.
+            if not db_path.exists():
+                shutil.copyfile(source, db_path)
+    else:
+        if db_path.exists():
+            db_path.unlink()
+        tagbattle.process_csv(csv_path, db_path)
 
     pairs = ranking.load_pairs(db_path)
     leaderboard = ranking.compute_rankings(pairs)
@@ -201,6 +306,14 @@ table.leaderboard tbody tr:nth-child(even) {background: #f8fafc;}
 .chart img {max-width: 100%; height: auto; border-radius: 0.75rem; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);}
 .methodology {background: #eef2ff; border-radius: 1rem;}
 .methodology ol {line-height: 1.7;}
+.experiments {background: white; border-radius: 1rem; box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12); margin-top: 2rem; padding-bottom: 2rem;}
+.experiments h2 {margin-top: 0; padding: 2rem 1.5rem 0;}
+.experiments p {padding: 0 1.5rem;}
+.experiments-metrics {display: flex; flex-wrap: wrap; gap: 1rem; padding: 1rem 1.5rem;}
+.experiments-accuracy {font-style: italic; color: #334155;}
+.experiments-table {width: calc(100% - 3rem); margin: 1rem 1.5rem; border-collapse: collapse;}
+.experiments-table th, .experiments-table td {border-bottom: 1px solid #e5e7eb; padding: 0.75rem 1rem; text-align: left;}
+.experiments-table thead {background: #f1f5f9;}
 .downloads ul {list-style: none; padding: 0;}
 .downloads li {margin: 0.5rem 0;}
 .downloads a {color: #0b6ce3; text-decoration: none; font-weight: 600;}
@@ -219,13 +332,26 @@ footer {text-align: center; padding: 2rem 1.5rem 3rem; color: #6b7280;}
         "Top tags chart": chart_path,
     }
 
-    _build_index_html(output_dir, stats, leaderboard, chart_path, artifact_links, csv_path)
+    experiments_summary: Optional[Dict[str, Any]] = None
+    if tasks_db is not None and tasks_db.exists():
+        experiments_summary = experiments.task_status(tasks_db)
+
+    _build_index_html(
+        output_dir,
+        stats,
+        leaderboard,
+        chart_path,
+        artifact_links,
+        csv_path,
+        experiments_summary,
+    )
 
     metadata = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "source_csv": str(csv_path),
         "stats": stats,
         "artifacts": {label: str(path.relative_to(output_dir)) for label, path in artifact_links.items()},
+        "experiments": experiments_summary,
     }
     (output_dir / "metadata.json").write_text(
         json.dumps(metadata, indent=2) + "\n",
@@ -244,9 +370,26 @@ def main() -> None:
         default=Path("build/site"),
         help="Directory where the static site should be written",
     )
+    parser.add_argument(
+        "--precomputed-database",
+        type=Path,
+        default=None,
+        help="Optional precomputed battles SQLite database",
+    )
+    parser.add_argument(
+        "--tasks-db",
+        type=Path,
+        default=None,
+        help="Optional experiments task database for progress reporting",
+    )
     args = parser.parse_args()
 
-    build_site(args.csv, args.output)
+    build_site(
+        args.csv,
+        args.output,
+        precomputed_database=args.precomputed_database,
+        tasks_db=args.tasks_db,
+    )
 
 
 if __name__ == "__main__":

--- a/padjective/experiments.py
+++ b/padjective/experiments.py
@@ -1,0 +1,435 @@
+"""Utilities for managing hold-out experiments on tag ordering."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from . import ranking
+
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@dataclass
+class Task:
+    """Representation of a single hold-out experiment request."""
+
+    task_id: int
+    seed: int
+    test_fraction: float
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS holdout_tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            seed INTEGER NOT NULL UNIQUE,
+            test_fraction REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at TEXT NOT NULL,
+            started_at TEXT,
+            completed_at TEXT,
+            total_pairs INTEGER,
+            evaluated_pairs INTEGER,
+            skipped_pairs INTEGER,
+            correct_predictions REAL,
+            accuracy REAL,
+            coverage REAL,
+            error_message TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_holdout_tasks_status
+            ON holdout_tasks(status)
+        """
+    )
+
+
+def ensure_tasks(
+    tasks_db: Path,
+    total_tasks: int,
+    *,
+    test_fraction: float,
+    seed_offset: int = 0,
+) -> None:
+    """Ensure ``total_tasks`` experiment entries exist in ``tasks_db``."""
+
+    now = datetime.utcnow().strftime(ISO_FORMAT)
+    with _connect(tasks_db) as conn:
+        _ensure_schema(conn)
+        existing = conn.execute("SELECT COUNT(*) FROM holdout_tasks").fetchone()[0]
+        missing = max(total_tasks - existing, 0)
+        if not missing:
+            return
+        for i in range(existing, existing + missing):
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO holdout_tasks
+                    (seed, test_fraction, status, created_at)
+                VALUES (?, ?, 'pending', ?)
+                """,
+                (seed_offset + i, test_fraction, now),
+            )
+
+
+def _select_pending_tasks(
+    conn: sqlite3.Connection, limit: int
+) -> List[Task]:
+    rows = conn.execute(
+        """
+        SELECT id, seed, test_fraction
+        FROM holdout_tasks
+        WHERE status = 'pending'
+        ORDER BY id
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    return [Task(task_id=row["id"], seed=row["seed"], test_fraction=row["test_fraction"]) for row in rows]
+
+
+def _mark_running(conn: sqlite3.Connection, task_ids: Sequence[int]) -> None:
+    if not task_ids:
+        return
+    now = datetime.utcnow().strftime(ISO_FORMAT)
+    conn.executemany(
+        """
+        UPDATE holdout_tasks
+        SET status = 'running', started_at = ?
+        WHERE id = ? AND status = 'pending'
+        """,
+        [(now, task_id) for task_id in task_ids],
+    )
+
+
+def _finalise_task(
+    conn: sqlite3.Connection,
+    task_id: int,
+    *,
+    status: str,
+    metrics: Dict[str, Any],
+    error_message: Optional[str] = None,
+) -> None:
+    now = datetime.utcnow().strftime(ISO_FORMAT)
+    conn.execute(
+        """
+        UPDATE holdout_tasks
+        SET status = ?,
+            completed_at = ?,
+            total_pairs = ?,
+            evaluated_pairs = ?,
+            skipped_pairs = ?,
+            correct_predictions = ?,
+            accuracy = ?,
+            coverage = ?,
+            error_message = ?
+        WHERE id = ?
+        """,
+        (
+            status,
+            now,
+            metrics.get("total_pairs"),
+            metrics.get("evaluated_pairs"),
+            metrics.get("skipped_pairs"),
+            metrics.get("correct_predictions"),
+            metrics.get("accuracy"),
+            metrics.get("coverage"),
+            error_message,
+            task_id,
+        ),
+    )
+
+
+def _evaluate_holdout(
+    pairs: Sequence[Tuple[str, str]],
+    *,
+    seed: int,
+    test_fraction: float,
+) -> Dict[str, Any]:
+    """Compute hold-out accuracy metrics for a random split of ``pairs``."""
+
+    if not pairs:
+        return {
+            "total_pairs": 0,
+            "evaluated_pairs": 0,
+            "skipped_pairs": 0,
+            "correct_predictions": 0.0,
+            "accuracy": None,
+            "coverage": 0.0,
+        }
+
+    rng = random.Random(seed)
+    shuffled = list(pairs)
+    rng.shuffle(shuffled)
+
+    test_size = max(int(len(shuffled) * test_fraction), 1)
+    test_pairs = shuffled[:test_size]
+    train_pairs = shuffled[test_size:]
+
+    if not train_pairs:
+        return {
+            "total_pairs": len(test_pairs),
+            "evaluated_pairs": 0,
+            "skipped_pairs": len(test_pairs),
+            "correct_predictions": 0.0,
+            "accuracy": None,
+            "coverage": 0.0,
+        }
+
+    leaderboard = ranking.compute_rankings(list(train_pairs))
+    score_lookup = dict(zip(leaderboard["tag"], leaderboard["score"]))
+
+    evaluated = 0
+    skipped = 0
+    correct = 0.0
+    for winner, loser in test_pairs:
+        winner_score = score_lookup.get(winner)
+        loser_score = score_lookup.get(loser)
+        if winner_score is None or loser_score is None:
+            skipped += 1
+            continue
+        evaluated += 1
+        if winner_score > loser_score:
+            correct += 1.0
+        elif winner_score == loser_score:
+            correct += 0.5
+
+    accuracy = correct / evaluated if evaluated else None
+    coverage = evaluated / len(test_pairs) if test_pairs else 0.0
+
+    return {
+        "total_pairs": len(test_pairs),
+        "evaluated_pairs": evaluated,
+        "skipped_pairs": skipped,
+        "correct_predictions": correct,
+        "accuracy": accuracy,
+        "coverage": coverage,
+    }
+
+
+def run_tasks(
+    *,
+    tasks_db: Path,
+    database: Path,
+    take: int,
+) -> List[Dict[str, Any]]:
+    """Run up to ``take`` pending tasks against ``database``."""
+
+    if take <= 0:
+        return []
+
+    pairs = ranking.load_pairs(database)
+    results: List[Dict[str, Any]] = []
+
+    with _connect(tasks_db) as conn:
+        _ensure_schema(conn)
+        tasks = _select_pending_tasks(conn, take)
+        if not tasks:
+            return []
+        _mark_running(conn, [task.task_id for task in tasks])
+
+    for task in tasks:
+        try:
+            metrics = _evaluate_holdout(pairs, seed=task.seed, test_fraction=task.test_fraction)
+        except Exception as exc:  # pragma: no cover - defensive programming
+            with _connect(tasks_db) as conn:
+                _finalise_task(
+                    conn,
+                    task.task_id,
+                    status="error",
+                    metrics={
+                        "total_pairs": None,
+                        "evaluated_pairs": None,
+                        "skipped_pairs": None,
+                        "correct_predictions": None,
+                        "accuracy": None,
+                        "coverage": None,
+                    },
+                    error_message=str(exc),
+                )
+            continue
+
+        with _connect(tasks_db) as conn:
+            _finalise_task(conn, task.task_id, status="completed", metrics=metrics)
+        results.append({"task": task, "metrics": metrics})
+
+    return results
+
+
+def task_status(tasks_db: Path) -> Dict[str, Any]:
+    """Return aggregate statistics about tasks stored in ``tasks_db``."""
+
+    with _connect(tasks_db) as conn:
+        _ensure_schema(conn)
+        counts = {row["status"]: row["count"] for row in conn.execute(
+            """
+            SELECT status, COUNT(*) AS count
+            FROM holdout_tasks
+            GROUP BY status
+            """
+        )}
+
+        completed_metrics = conn.execute(
+            """
+            SELECT AVG(accuracy) AS mean_accuracy,
+                   AVG(coverage) AS mean_coverage,
+                   MIN(created_at) AS first_created,
+                   MAX(completed_at) AS last_completed,
+                   COUNT(*) AS completed_tasks
+            FROM holdout_tasks
+            WHERE status = 'completed' AND accuracy IS NOT NULL
+            """
+        ).fetchone()
+
+        test_fraction = conn.execute(
+            "SELECT test_fraction FROM holdout_tasks LIMIT 1"
+        ).fetchone()
+
+        recent = conn.execute(
+            """
+            SELECT id, seed, accuracy, coverage, evaluated_pairs, completed_at
+            FROM holdout_tasks
+            WHERE status = 'completed' AND completed_at IS NOT NULL
+            ORDER BY completed_at DESC
+            LIMIT 10
+            """
+        ).fetchall()
+
+    total = sum(counts.values())
+    return {
+        "total": total,
+        "counts": counts,
+        "test_fraction": test_fraction[0] if test_fraction else None,
+        "mean_accuracy": completed_metrics["mean_accuracy"] if completed_metrics else None,
+        "mean_coverage": completed_metrics["mean_coverage"] if completed_metrics else None,
+        "completed_tasks": completed_metrics["completed_tasks"] if completed_metrics else 0,
+        "first_created": completed_metrics["first_created"] if completed_metrics else None,
+        "last_completed": completed_metrics["last_completed"] if completed_metrics else None,
+        "recent": [dict(row) for row in recent],
+    }
+
+
+def _format_status(status: Dict[str, Any]) -> str:
+    if not status["total"]:
+        return "No tasks found."
+    counts = status["counts"]
+    lines = [
+        f"Total tasks: {status['total']}",
+        f"  pending: {counts.get('pending', 0)}",
+        f"  running: {counts.get('running', 0)}",
+        f"  completed: {counts.get('completed', 0)}",
+        f"  error: {counts.get('error', 0)}",
+    ]
+    if status["completed_tasks"]:
+        mean_accuracy = status["mean_accuracy"]
+        mean_coverage = status["mean_coverage"]
+        lines.append(
+            "  mean accuracy: {:.2%}".format(mean_accuracy) if mean_accuracy is not None else "  mean accuracy: n/a"
+        )
+        lines.append(
+            "  mean coverage: {:.2%}".format(mean_coverage) if mean_coverage is not None else "  mean coverage: n/a"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage hold-out experiment tasks")
+    parser.add_argument(
+        "--tasks-db",
+        type=Path,
+        default=Path("holdout_tasks.sqlite"),
+        help="Path to the SQLite database storing experiment tasks",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Ensure tasks exist")
+    init_parser.add_argument("--total", type=int, default=1000, help="Total number of tasks to ensure")
+    init_parser.add_argument(
+        "--test-fraction",
+        type=float,
+        default=0.2,
+        help="Fraction of battles to reserve for testing",
+    )
+    init_parser.add_argument(
+        "--seed-offset",
+        type=int,
+        default=0,
+        help="Offset applied to generated random seeds",
+    )
+
+    status_parser = subparsers.add_parser("status", help="Display current task progress")
+
+    run_parser = subparsers.add_parser("run", help="Execute pending tasks")
+    run_parser.add_argument("--database", type=Path, required=True, help="SQLite battles database")
+    run_parser.add_argument(
+        "--take",
+        type=int,
+        default=100,
+        help="Maximum number of pending tasks to execute",
+    )
+    run_parser.add_argument(
+        "--ensure-total",
+        type=int,
+        default=None,
+        help="Ensure at least this many tasks exist before running",
+    )
+    run_parser.add_argument(
+        "--test-fraction",
+        type=float,
+        default=0.2,
+        help="Test fraction used when creating missing tasks",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init":
+        ensure_tasks(
+            args.tasks_db,
+            args.total,
+            test_fraction=args.test_fraction,
+            seed_offset=args.seed_offset,
+        )
+    elif args.command == "status":
+        status = task_status(args.tasks_db)
+        print(_format_status(status))
+    elif args.command == "run":
+        if args.ensure_total is not None:
+            ensure_tasks(
+                args.tasks_db,
+                args.ensure_total,
+                test_fraction=args.test_fraction,
+            )
+        results = run_tasks(tasks_db=args.tasks_db, database=args.database, take=args.take)
+        if not results:
+            print("No pending tasks executed.")
+            return
+        for result in results:
+            task: Task = result["task"]
+            metrics: Dict[str, Any] = result["metrics"]
+            accuracy = metrics["accuracy"]
+            coverage = metrics["coverage"]
+            accuracy_text = f"{accuracy:.2%}" if accuracy is not None else "n/a"
+            coverage_text = f"{coverage:.2%}" if coverage is not None else "n/a"
+            print(
+                f"Task {task.task_id} (seed={task.seed}) accuracy={accuracy_text} coverage={coverage_text}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,37 @@
+import sqlite3
+from pathlib import Path
+
+from padjective import experiments
+
+
+def _make_battles_db(path: Path) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE battles (winner_tag TEXT, loser_tag TEXT)")
+    rows = [
+        ("RED", "BLUE"),
+        ("RED", "GREEN"),
+        ("BLUE", "GREEN"),
+        ("YELLOW", "GREEN"),
+        ("BLUE", "YELLOW"),
+    ]
+    conn.executemany("INSERT INTO battles VALUES (?, ?)", rows)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_run_tasks_and_status(tmp_path):
+    battles_db = _make_battles_db(tmp_path / "battles.sqlite")
+    tasks_db = tmp_path / "tasks.sqlite"
+
+    experiments.ensure_tasks(tasks_db, total_tasks=3, test_fraction=0.4)
+    results = experiments.run_tasks(tasks_db=tasks_db, database=battles_db, take=2)
+
+    assert len(results) == 2
+    status = experiments.task_status(tasks_db)
+    assert status["total"] == 3
+    assert status["counts"].get("completed", 0) == 2
+    assert status["counts"].get("pending", 0) == 1
+    assert status["completed_tasks"] == 2
+    # At least one completed task should report accuracy.
+    assert status["mean_accuracy"] is None or 0 <= status["mean_accuracy"] <= 1


### PR DESCRIPTION
## Summary
- add a `padjective.experiments` module to manage hold-out evaluation tasks and expose a CLI
- surface experiment progress on the static site and allow reusing a precomputed battles database
- extend the cron job and tests/README so hold-out results are executed and documented automatically

## Testing
- uv run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7fc499e548325874173f0f10564f0