### PR TITLE
Show synset progress on the site

### DIFF
--- a/cronscript.sh
+++ b/cronscript.sh
@@ -12,14 +12,18 @@ TASKS_DB=${PADJECTIVE_TASKS_DB:-data/holdout_tasks.sqlite}
 TOTAL_TASKS=${PADJECTIVE_TOTAL_HOLDOUT_TASKS:-5000}
 TASK_BATCH=${PADJECTIVE_TASK_BATCH:-250}
 BATTLES_DB=${PADJECTIVE_BATTLES_DB:-build/battles.sqlite}
+SYNSETS_DB=${PADJECTIVE_SYNSETS_DB:-data/product_synsets.sqlite}
+SYNSETS_BATCH=${PADJECTIVE_SYNSETS_BATCH:-1000}
 
 mkdir -p "$(dirname "$TASKS_DB")"
 mkdir -p "$(dirname "$BATTLES_DB")"
+mkdir -p "$(dirname "$SYNSETS_DB")"
 
+uv run -m padjective.product_synsets --csv "$CSV_PATH" --database "$SYNSETS_DB" --batch "$SYNSETS_BATCH"
 uv run padjective/tagbattle.py --csv "$CSV_PATH" --database "$BATTLES_DB"
 uv run -m padjective.experiments init --tasks-db "$TASKS_DB" --total "$TOTAL_TASKS"
 uv run -m padjective.experiments run --tasks-db "$TASKS_DB" --database "$BATTLES_DB" --take "$TASK_BATCH"
-uv run -m padjective.build_site --csv "$CSV_PATH" --output "$OUTPUT_DIR" --precomputed-database "$BATTLES_DB" --tasks-db "$TASKS_DB"
+uv run -m padjective.build_site --csv "$CSV_PATH" --output "$OUTPUT_DIR" --precomputed-database "$BATTLES_DB" --tasks-db "$TASKS_DB" --synset-db "$SYNSETS_DB"
 
 REMOTE_SITE="padjective@merah.cassia.ifost.org.au:/var/www/vhosts/padjective.symmachus.org/htdocs/"
 rsync -avz --delete "$OUTPUT_DIR/" "$REMOTE_SITE"

--- a/padjective/build_site.py
+++ b/padjective/build_site.py
@@ -1,15 +1,16 @@
-"""Build a static website showcasing the latest tag ranking results."""
+"""Build a static website showcasing tag rankings and synset progress."""
 
 from __future__ import annotations
 
 import argparse
 import csv
+import html
 import json
 import shutil
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import pandas as pd
 
@@ -66,6 +67,7 @@ def _build_index_html(
     artifact_links: Dict[str, Path],
     source_csv: Path,
     experiments_summary: Optional[Dict[str, Any]] = None,
+    synset_summary: Optional[Dict[str, Any]] = None,
 ) -> None:
     top_table = leaderboard.head(20).to_html(index=False, classes="leaderboard")
     generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -159,6 +161,92 @@ def _build_index_html(
   </section>
 """
 
+    synset_section = ""
+    if synset_summary:
+        processed = synset_summary.get("processed", 0)
+        remaining = synset_summary.get("remaining", 0)
+        not_found = synset_summary.get("not_found", 0)
+        progress_pct = synset_summary.get("progress_pct")
+        rate_per_day = synset_summary.get("rate_per_day")
+        rate_text = "n/a"
+        if rate_per_day is not None and rate_per_day > 0:
+            rate_text = f"{rate_per_day:,.1f} products/day"
+        eta_text = synset_summary.get("eta_text") or "n/a"
+        completion_text = synset_summary.get("estimated_completion_text") or ""
+        completion_fragment = f" {html.escape(completion_text)}" if completion_text else ""
+        last_processed_text = synset_summary.get("last_processed_text") or ""
+        last_processed_fragment = f" {html.escape(last_processed_text)}" if last_processed_text else ""
+
+        top_synsets = synset_summary.get("synsets", [])[:10]
+        top_rows: Iterable[str] = []
+        if top_synsets:
+            top_rows = [
+                "<tr>"
+                f"<td><a href=\"synsets/{html.escape(s['synset_id'])}.html\">{html.escape(s.get('synset_name') or s['synset_id'])}</a></td>"
+                f"<td>{html.escape(s['synset_id'])}</td>"
+                f"<td>{s['product_count']:,}</td>"
+                f"<td>{s['share'] * 100:.1f}%</td>"
+                "</tr>"
+                for s in top_synsets
+            ]
+        top_table = "<table class=\"synset-table\"><thead><tr><th>Synset</th><th>ID</th><th>Products</th><th>Share</th></tr></thead><tbody>"
+        if top_synsets:
+            top_table += "\n".join(top_rows)
+        else:
+            top_table += "<tr><td colspan=\"4\">No synsets processed yet.</td></tr>"
+        top_table += "</tbody></table>"
+
+        progress_text = f"{progress_pct:.1f}%" if progress_pct is not None else "n/a"
+        not_found_examples = synset_summary.get("not_found_examples") or []
+        not_found_block = ""
+        if not_found_examples:
+            items = "\n".join(
+                f"<li>{html.escape(title)}</li>" for title in not_found_examples if title
+            )
+            if items:
+                not_found_block = (
+                    "<div class=\"synset-not-found\">"
+                    "<h4>Recent products without a synset</h4>"
+                    f"<ul>{items}</ul>"
+                    "</div>"
+                )
+
+        synset_section = f"""
+  <section class=\"synset-progress\">
+    <div class=\"synset-header\">
+      <h2>WordNet synset tagging</h2>
+      <p>We ask GPT models to map each product to the closest WordNet synset.</p>
+    </div>
+    <div class=\"metrics synset-metrics\">
+      <div class=\"metric\">
+        <span class=\"value\">{processed:,}</span>
+        <span class=\"label\">Products classified</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{remaining:,}</span>
+        <span class=\"label\">Products remaining</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{not_found:,}</span>
+        <span class=\"label\">No WordNet match</span>
+      </div>
+      <div class=\"metric\">
+        <span class=\"value\">{progress_text}</span>
+        <span class=\"label\">Coverage so far</span>
+      </div>
+    </div>
+    <p class=\"synset-eta\">
+      Processing rate: {rate_text}. Remaining work estimated completion: {eta_text}.{completion_fragment}{last_processed_fragment}
+    </p>
+    <div class=\"synset-top\">
+      <h3>Most common synsets</h3>
+      {top_table}
+      <p><a href=\"synsets/index.html\">Explore all processed synsets &rarr;</a></p>
+    </div>
+    {not_found_block}
+  </section>
+"""
+
     html = f"""<!DOCTYPE html>
 <html lang=\"en\">
 <head>
@@ -202,6 +290,8 @@ def _build_index_html(
     </figure>
   </section>
 
+  {synset_section}
+
   <section class=\"methodology\">
     <h2>How the rankings work</h2>
     <ol>
@@ -232,12 +322,315 @@ def _build_index_html(
     (output_dir / "index.html").write_text(html, encoding="utf-8")
 
 
+def _parse_sqlite_timestamp(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace(" ", "T"))
+    except ValueError:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+            try:
+                return datetime.strptime(value, fmt)
+            except ValueError:
+                continue
+    return None
+
+
+def _format_duration(hours: float) -> str:
+    if hours <= 0:
+        return "soon"
+    total_seconds = int(hours * 3600)
+    days, remainder = divmod(total_seconds, 86400)
+    hrs, remainder = divmod(remainder, 3600)
+    minutes = remainder // 60
+    parts = []
+    if days:
+        parts.append(f"{days} day{'s' if days != 1 else ''}")
+    if hrs:
+        parts.append(f"{hrs} hour{'s' if hrs != 1 else ''}")
+    if minutes and not days:
+        parts.append(f"{minutes} min")
+    return " ".join(parts) or "<1 min"
+
+
+def _collect_synset_progress(
+    db_path: Path, total_products: int
+) -> Optional[Dict[str, Any]]:
+    if not db_path.exists():
+        return None
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        summary_row = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS processed,
+                SUM(CASE WHEN not_found = 1 THEN 1 ELSE 0 END) AS not_found,
+                MIN(processed_at) AS first_processed,
+                MAX(processed_at) AS last_processed
+            FROM product_synsets
+            """
+        ).fetchone()
+        processed = int(summary_row["processed"] or 0)
+        if processed == 0:
+            return {
+                "processed": 0,
+                "remaining": max(total_products, 0),
+                "not_found": 0,
+                "progress_pct": 0.0 if total_products else None,
+                "synsets": [],
+                "eta_text": "n/a",
+            }
+
+        not_found = int(summary_row["not_found"] or 0)
+        remaining = max(total_products - processed, 0)
+        progress_pct = (processed / total_products * 100.0) if total_products else None
+
+        last_processed = _parse_sqlite_timestamp(summary_row["last_processed"])
+        last_processed_text = (
+            f"Last processed at {last_processed.isoformat(timespec='seconds')}"
+            if last_processed
+            else ""
+        )
+
+        recent_rows = conn.execute(
+            """
+            SELECT processed_at FROM product_synsets
+            WHERE processed_at IS NOT NULL
+            ORDER BY processed_at DESC
+            LIMIT 500
+            """
+        ).fetchall()
+        recent_times = [
+            _parse_sqlite_timestamp(row[0])
+            for row in reversed(recent_rows)
+            if row[0] is not None
+        ]
+        rate_per_hour: Optional[float] = None
+        eta_text = None
+        estimated_completion_text = None
+        if len(recent_times) >= 2:
+            elapsed = (recent_times[-1] - recent_times[0]).total_seconds() / 3600
+            if elapsed > 0:
+                window_processed = len(recent_times)
+                rate_per_hour = window_processed / elapsed
+                if remaining > 0:
+                    eta_hours = remaining / rate_per_hour
+                    eta_text = _format_duration(eta_hours)
+                    if last_processed:
+                        projected = last_processed + timedelta(hours=eta_hours)
+                        estimated_completion_text = (
+                            f"Projected completion around {projected.isoformat(timespec='minutes')}"
+                        )
+                else:
+                    eta_text = "complete"
+
+        if eta_text is None:
+            eta_text = "n/a"
+
+        synset_rows = conn.execute(
+            """
+            SELECT synset_id, synset_name, synset_definition, COUNT(*) AS product_count
+            FROM product_synsets
+            WHERE not_found = 0 AND synset_id IS NOT NULL
+            GROUP BY synset_id, synset_name, synset_definition
+            ORDER BY product_count DESC, synset_id
+            """
+        ).fetchall()
+
+        synsets: list[Dict[str, Any]] = []
+        for row in synset_rows:
+            synset_id = row["synset_id"]
+            if not synset_id:
+                continue
+            products = conn.execute(
+                """
+                SELECT product_id, title, tags, confidence, reason, processed_at
+                FROM product_synsets
+                WHERE synset_id = ? AND not_found = 0
+                ORDER BY COALESCE(confidence, 0) DESC, title COLLATE NOCASE
+                """,
+                (synset_id,),
+            ).fetchall()
+            product_records = [
+                {
+                    "product_id": product["product_id"],
+                    "title": product["title"],
+                    "tags": product["tags"],
+                    "confidence": product["confidence"],
+                    "reason": product["reason"],
+                    "processed_at": product["processed_at"],
+                }
+                for product in products
+            ]
+            share = (row["product_count"] or 0) / processed if processed else 0.0
+            synsets.append(
+                {
+                    "synset_id": synset_id,
+                    "synset_name": row["synset_name"],
+                    "synset_definition": row["synset_definition"],
+                    "product_count": int(row["product_count"] or 0),
+                    "share": share,
+                    "products": product_records,
+                }
+            )
+
+        not_found_examples = conn.execute(
+            """
+            SELECT title FROM product_synsets
+            WHERE not_found = 1 AND title IS NOT NULL AND title != ''
+            ORDER BY processed_at DESC
+            LIMIT 5
+            """
+        ).fetchall()
+
+        return {
+            "processed": processed,
+            "remaining": remaining,
+            "not_found": not_found,
+            "progress_pct": progress_pct,
+            "rate_per_hour": rate_per_hour,
+            "rate_per_day": rate_per_hour * 24 if rate_per_hour else None,
+            "eta_text": eta_text,
+            "estimated_completion_text": estimated_completion_text,
+            "last_processed_text": last_processed_text,
+            "synsets": synsets,
+            "not_found_examples": [row[0] for row in not_found_examples],
+        }
+    finally:
+        conn.close()
+
+
+def _build_synset_pages(output_dir: Path, synset_summary: Dict[str, Any]) -> None:
+    synsets = synset_summary.get("synsets") or []
+    if not synsets:
+        return
+
+    synsets_dir = output_dir / "synsets"
+    synsets_dir.mkdir(parents=True, exist_ok=True)
+
+    def _product_rows(products: Iterable[Dict[str, Any]]) -> str:
+        rows = []
+        for product in products:
+            confidence = product.get("confidence")
+            if confidence is None:
+                confidence_text = "n/a"
+            else:
+                confidence_text = f"{confidence:.2f}"
+            reason = html.escape(product.get("reason") or "")
+            if reason:
+                reason_html = f"<details><summary>Why?</summary><p>{reason}</p></details>"
+            else:
+                reason_html = ""
+            rows.append(
+                "<tr>"
+                f"<td>{product['product_id']}</td>"
+                f"<td>{html.escape(product.get('title') or '')}</td>"
+                f"<td>{html.escape(product.get('tags') or '')}</td>"
+                f"<td>{confidence_text}</td>"
+                f"<td>{reason_html}</td>"
+                "</tr>"
+            )
+        return "\n".join(rows) if rows else "<tr><td colspan=\"5\">No products recorded.</td></tr>"
+
+    index_rows = []
+    for synset in synsets:
+        synset_id = synset["synset_id"]
+        name = synset.get("synset_name") or synset_id
+        definition = html.escape(synset.get("synset_definition") or "")
+        product_count = synset["product_count"]
+        share_pct = synset["share"] * 100 if synset["share"] is not None else 0.0
+
+        index_rows.append(
+            "<tr>"
+            f"<td><a href=\"{synset_id}.html\">{html.escape(name)}</a></td>"
+            f"<td>{html.escape(synset_id)}</td>"
+            f"<td>{product_count:,}</td>"
+            f"<td>{share_pct:.1f}%</td>"
+            f"<td>{definition}</td>"
+            "</tr>"
+        )
+
+        products_html = _product_rows(synset.get("products", []))
+        synset_page = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>{html.escape(name)} — WordNet synset</title>
+  <link rel=\"stylesheet\" href=\"../assets/styles.css\" />
+</head>
+<body class=\"synset-page\">
+  <header class=\"synset-hero\">
+    <p><a href=\"../index.html\">&larr; Back to overview</a></p>
+    <h1>{html.escape(name)}</h1>
+    <p class=\"synset-id\">{html.escape(synset_id)}</p>
+    <p class=\"synset-definition\">{definition or 'Definition unavailable.'}</p>
+    <p class=\"synset-count\">{product_count:,} product{'s' if product_count != 1 else ''} mapped here.</p>
+  </header>
+  <main class=\"synset-content\">
+    <table class=\"synset-products\">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Title</th>
+          <th>Tags</th>
+          <th>Confidence</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {products_html}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>
+"""
+        (synsets_dir / f"{synset_id}.html").write_text(synset_page, encoding="utf-8")
+
+    index_html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>WordNet synsets overview</title>
+  <link rel=\"stylesheet\" href=\"../assets/styles.css\" />
+</head>
+<body class=\"synset-page\">
+  <header class=\"synset-hero\">
+    <p><a href=\"../index.html\">&larr; Back to overview</a></p>
+    <h1>All processed synsets</h1>
+    <p class=\"synset-definition\">Browse every WordNet concept currently linked to Shopify products.</p>
+  </header>
+  <main class=\"synset-content\">
+    <table class=\"synset-products\">
+      <thead>
+        <tr>
+          <th>Synset</th>
+          <th>ID</th>
+          <th>Products</th>
+          <th>Share</th>
+          <th>Definition</th>
+        </tr>
+      </thead>
+      <tbody>
+        {''.join(index_rows)}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>
+"""
+    (synsets_dir / "index.html").write_text(index_html, encoding="utf-8")
+
+
 def build_site(
     csv_path: Path,
     output_dir: Path,
     *,
     precomputed_database: Optional[Path] = None,
     tasks_db: Optional[Path] = None,
+    synset_db: Optional[Path] = None,
 ) -> Dict[str, Any]:
     csv_path = csv_path.resolve()
     _ensure_clean_directory(output_dir)
@@ -304,6 +697,21 @@ table.leaderboard thead {background: #f1f5f9;}
 table.leaderboard tbody tr:nth-child(even) {background: #f8fafc;}
 .chart {text-align: center; padding: 0 1rem 2rem;}
 .chart img {max-width: 100%; height: auto; border-radius: 0.75rem; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.1);}
+.synset-progress {background: white; border-radius: 1rem; box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12); margin-top: 2rem; padding-bottom: 2rem;}
+.synset-progress .synset-header {padding: 2rem 1.5rem 0;}
+.synset-progress .synset-header p {margin: 0.5rem 0 0; color: #475569;}
+.synset-progress .synset-top {padding: 0 1.5rem 1.5rem;}
+.synset-progress .synset-top h3 {margin-bottom: 0.5rem;}
+.synset-progress .synset-top a {color: #0b6ce3; font-weight: 600; text-decoration: none;}
+.synset-progress .synset-top a:hover {text-decoration: underline;}
+.synset-eta {padding: 1rem 1.5rem 0; text-align: center; font-style: italic; color: #475569;}
+.synset-not-found {padding: 0 1.5rem 1.5rem;}
+.synset-not-found h4 {margin-bottom: 0.5rem;}
+.synset-not-found ul {margin: 0; padding-left: 1.25rem; color: #475569;}
+.synset-table {width: 100%; border-collapse: collapse; background: white;}
+.synset-table th, .synset-table td {padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; text-align: left;}
+.synset-table thead {background: #f8fafc;}
+.synset-table tbody tr:nth-child(even) {background: #f8fafc;}
 .methodology {background: #eef2ff; border-radius: 1rem;}
 .methodology ol {line-height: 1.7;}
 .experiments {background: white; border-radius: 1rem; box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12); margin-top: 2rem; padding-bottom: 2rem;}
@@ -319,7 +727,20 @@ table.leaderboard tbody tr:nth-child(even) {background: #f8fafc;}
 .downloads a {color: #0b6ce3; text-decoration: none; font-weight: 600;}
 .downloads a:hover {text-decoration: underline;}
 footer {text-align: center; padding: 2rem 1.5rem 3rem; color: #6b7280;}
-@media (max-width: 700px) {.metrics {flex-direction: column;} header.hero {padding: 2.5rem 1rem;} header.hero h1 {font-size: 2rem;}}
+body.synset-page {font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; margin: 0; color: #1f2937; background: #f7f7fb;}
+.synset-hero {background: linear-gradient(135deg, #6366f1, #8b5cf6); color: white; padding: 2.5rem 1.5rem; text-align: center;}
+.synset-hero a {color: white; opacity: 0.85; text-decoration: none;}
+.synset-hero a:hover {opacity: 1; text-decoration: underline;}
+.synset-hero h1 {margin: 0.5rem 0 0; font-size: 2.25rem;}
+.synset-hero .synset-id {font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; margin: 0.5rem 0; opacity: 0.85;}
+.synset-hero .synset-count {margin-top: 0.5rem; font-weight: 600;}
+.synset-content {max-width: 70rem; margin: 0 auto; padding: 2rem 1.5rem 3rem;}
+table.synset-products {width: 100%; border-collapse: collapse; background: white; border-radius: 1rem; overflow: hidden; box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);}
+table.synset-products th, table.synset-products td {padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; text-align: left; vertical-align: top;}
+table.synset-products thead {background: #f1f5f9;}
+table.synset-products tbody tr:nth-child(even) {background: #f8fafc;}
+.synset-products details {color: #334155;}
+@media (max-width: 700px) {.metrics {flex-direction: column;} header.hero {padding: 2.5rem 1rem;} header.hero h1 {font-size: 2rem;} .synset-content {padding: 1.5rem 1rem 2rem;}}
 """,
         encoding="utf-8",
     )
@@ -336,6 +757,12 @@ footer {text-align: center; padding: 2rem 1.5rem 3rem; color: #6b7280;}
     if tasks_db is not None and tasks_db.exists():
         experiments_summary = experiments.task_status(tasks_db)
 
+    synset_summary: Optional[Dict[str, Any]] = None
+    if synset_db is not None:
+        synset_summary = _collect_synset_progress(synset_db, stats.get("products", 0))
+        if synset_summary:
+            _build_synset_pages(output_dir, synset_summary)
+
     _build_index_html(
         output_dir,
         stats,
@@ -344,6 +771,7 @@ footer {text-align: center; padding: 2rem 1.5rem 3rem; color: #6b7280;}
         artifact_links,
         csv_path,
         experiments_summary,
+        synset_summary,
     )
 
     metadata = {
@@ -352,6 +780,7 @@ footer {text-align: center; padding: 2rem 1.5rem 3rem; color: #6b7280;}
         "stats": stats,
         "artifacts": {label: str(path.relative_to(output_dir)) for label, path in artifact_links.items()},
         "experiments": experiments_summary,
+        "synsets": synset_summary,
     }
     (output_dir / "metadata.json").write_text(
         json.dumps(metadata, indent=2) + "\n",
@@ -382,6 +811,12 @@ def main() -> None:
         default=None,
         help="Optional experiments task database for progress reporting",
     )
+    parser.add_argument(
+        "--synset-db",
+        type=Path,
+        default=None,
+        help="Optional SQLite database with product synset classifications",
+    )
     args = parser.parse_args()
 
     build_site(
@@ -389,6 +824,7 @@ def main() -> None:
         args.output,
         precomputed_database=args.precomputed_database,
         tasks_db=args.tasks_db,
+        synset_db=args.synset_db,
     )
 
 

--- a/padjective/product_synsets.py
+++ b/padjective/product_synsets.py
@@ -1,0 +1,376 @@
+"""Utilities for classifying products into WordNet synsets.
+
+This module provides a small workflow that reads product information from a CSV
+file, asks an OpenAI model for the best matching WordNet synset (using tool
+calling for a structured response), and stores the results in a SQLite database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional
+
+try:  # pragma: no cover - optional dependency for type checking
+    from openai import OpenAI
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    OpenAI = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True, slots=True)
+class ProductRecord:
+    """A single product entry read from the CSV file."""
+
+    product_id: int
+    title: str
+    tags: str
+
+    @property
+    def description(self) -> str:
+        """Return a human readable description for prompting the model."""
+
+        if self.tags:
+            return f"Title: {self.title}\nTags: {self.tags}"
+        return f"Title: {self.title}"
+
+
+class CSVProductSource:
+    """Simple wrapper class that loads product data from a CSV file."""
+
+    def __init__(self, csv_path: Path) -> None:
+        self.csv_path = csv_path
+
+    def iter_products(self) -> Iterator[ProductRecord]:
+        """Yield :class:`ProductRecord` instances for each product in the CSV."""
+
+        with self.csv_path.open("r", newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            for index, row in enumerate(reader, start=1):
+                title = (row.get("title") or "").strip()
+                tags = (row.get("tags") or "").strip()
+                yield ProductRecord(product_id=index, title=title, tags=tags)
+
+
+@dataclass(slots=True)
+class SynsetResult:
+    """Structured result returned from the language model."""
+
+    synset_id: Optional[str]
+    synset_name: Optional[str]
+    synset_definition: Optional[str]
+    confidence: Optional[float]
+    not_found: bool
+    reason: Optional[str]
+    raw_response: str
+
+
+class SynsetDatabase:
+    """Convenience wrapper around the SQLite database used for results."""
+
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path
+        database_path.parent.mkdir(parents=True, exist_ok=True)
+        self.connection = sqlite3.connect(self.database_path)
+        self.connection.execute("PRAGMA journal_mode=WAL;")
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS product_synsets (
+                product_id INTEGER PRIMARY KEY,
+                title TEXT NOT NULL,
+                tags TEXT,
+                synset_id TEXT,
+                synset_name TEXT,
+                synset_definition TEXT,
+                confidence REAL,
+                not_found INTEGER NOT NULL,
+                reason TEXT,
+                model TEXT NOT NULL,
+                raw_response TEXT NOT NULL,
+                processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.connection.commit()
+
+    def processed_product_ids(self) -> set[int]:
+        cursor = self.connection.execute("SELECT product_id FROM product_synsets")
+        return {row[0] for row in cursor.fetchall()}
+
+    def store_result(self, product: ProductRecord, result: SynsetResult, model: str) -> None:
+        self.connection.execute(
+            """
+            INSERT OR REPLACE INTO product_synsets (
+                product_id,
+                title,
+                tags,
+                synset_id,
+                synset_name,
+                synset_definition,
+                confidence,
+                not_found,
+                reason,
+                model,
+                raw_response
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                product.product_id,
+                product.title,
+                product.tags,
+                result.synset_id,
+                result.synset_name,
+                result.synset_definition,
+                result.confidence,
+                int(result.not_found),
+                result.reason,
+                model,
+                result.raw_response,
+            ),
+        )
+        self.connection.commit()
+
+    def close(self) -> None:
+        self.connection.close()
+
+
+def _build_tool_spec() -> Dict[str, object]:
+    """Return the JSON schema used for tool calling."""
+
+    return {
+        "type": "function",
+        "function": {
+            "name": "record_synset",
+            "description": (
+                "Select the most appropriate WordNet synset for a product. "
+                "Respond with not_found=true if the concept is absent from WordNet."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "synset_id": {
+                        "type": "string",
+                        "description": "The WordNet synset id (e.g. 'n04379243').",
+                    },
+                    "synset_name": {
+                        "type": "string",
+                        "description": "Short lemma or gloss name of the synset.",
+                    },
+                    "synset_definition": {
+                        "type": "string",
+                        "description": "Definition of the synset from WordNet.",
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "minimum": 0.0,
+                        "maximum": 1.0,
+                        "description": (
+                            "Confidence between 0 and 1 that the synset is a good match."
+                        ),
+                    },
+                    "not_found": {
+                        "type": "boolean",
+                        "description": "Set to true if there is no matching synset in WordNet.",
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Explanation of how the synset was chosen or why none was found."
+                        ),
+                    },
+                },
+                "required": ["not_found"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _extract_tool_response(response_dict: Dict[str, object]) -> Dict[str, object]:
+    """Extract the tool call payload from the response dictionary."""
+
+    output_items = response_dict.get("output")
+    if not isinstance(output_items, list):
+        raise ValueError("Model response did not include any output items")
+
+    for item in output_items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "tool_call":
+            function = item.get("function", {})
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if isinstance(arguments, str):
+                return json.loads(arguments)
+            if isinstance(arguments, dict):
+                return arguments
+        content = item.get("content")
+        if isinstance(content, list):
+            for content_item in content:
+                if not isinstance(content_item, dict):
+                    continue
+                if content_item.get("type") == "tool_call":
+                    function = content_item.get("function", {})
+                    if not isinstance(function, dict):
+                        continue
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, str):
+                        return json.loads(arguments)
+                    if isinstance(arguments, dict):
+                        return arguments
+    raise ValueError("No tool call found in model response")
+
+
+def call_synset_model(client: "OpenAI", product: ProductRecord, *, model: str) -> SynsetResult:
+    """Ask the language model to pick a WordNet synset for the product."""
+
+    response = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a linguistic expert that maps product descriptions to "
+                    "Princeton WordNet synsets. Provide precise nouns and be explicit "
+                    "when a product does not exist in WordNet."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Determine the WordNet synset that best represents this product.\n"
+                    f"{product.description}\n"
+                    "Return the result using the record_synset function."
+                ),
+            },
+        ],
+        tools=[_build_tool_spec()],
+        tool_choice={"type": "function", "function": {"name": "record_synset"}},
+    )
+
+    response_dict = response.model_dump()
+    tool_payload = _extract_tool_response(response_dict)
+
+    not_found = bool(tool_payload.get("not_found"))
+    synset_id = tool_payload.get("synset_id")
+    synset_name = tool_payload.get("synset_name")
+    synset_definition = tool_payload.get("synset_definition")
+    confidence = tool_payload.get("confidence")
+    reason = tool_payload.get("reason" or None)
+
+    if not not_found:
+        if not synset_id:
+            raise ValueError("Model indicated a synset was found but no synset_id was provided")
+        if confidence is not None and not isinstance(confidence, (int, float)):
+            raise ValueError("Confidence value must be numeric when provided")
+    else:
+        synset_id = None
+        synset_name = None
+        synset_definition = None
+        confidence = None
+
+    return SynsetResult(
+        synset_id=synset_id,
+        synset_name=synset_name,
+        synset_definition=synset_definition,
+        confidence=float(confidence) if isinstance(confidence, (int, float)) else None,
+        not_found=not_found,
+        reason=tool_payload.get("reason"),
+        raw_response=json.dumps(response_dict),
+    )
+
+
+def process_products(
+    *,
+    csv_path: Path,
+    database_path: Path,
+    batch_size: int,
+    model: str,
+    client: Optional["OpenAI"] = None,
+) -> int:
+    """Process up to ``batch_size`` unprocessed products."""
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    if client is None:
+        if OpenAI is None:  # pragma: no cover - requires optional dependency
+            raise RuntimeError("The openai package is required to contact the API")
+        if not os.getenv("OPENAI_API_KEY"):
+            raise RuntimeError("OPENAI_API_KEY environment variable must be set to contact the API")
+        client = OpenAI()
+
+    source = CSVProductSource(csv_path)
+    database = SynsetDatabase(database_path)
+
+    try:
+        processed_ids = database.processed_product_ids()
+        processed_count = 0
+
+        for product in source.iter_products():
+            if product.product_id in processed_ids:
+                continue
+            result = call_synset_model(client, product, model=model)
+            database.store_result(product, result, model)
+            processed_ids.add(product.product_id)
+            processed_count += 1
+            if processed_count >= batch_size:
+                break
+    finally:
+        database.close()
+
+    return processed_count
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Classify products into WordNet synsets and store them in SQLite.",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=Path("products_point_one_percent_sample.csv"),
+        help="Path to the products CSV file.",
+    )
+    parser.add_argument(
+        "--database",
+        type=Path,
+        default=Path("data/product_synsets.sqlite"),
+        help="Path to the SQLite database that will store the results.",
+    )
+    parser.add_argument(
+        "--batch",
+        type=int,
+        default=1000,
+        help="Number of unprocessed products to classify in this run.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-5-mini",
+        help="OpenAI model to use for synset selection.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = _parse_args(argv)
+    processed = process_products(
+        csv_path=args.csv,
+        database_path=args.database,
+        batch_size=args.batch,
+        model=args.model,
+    )
+    print(f"Processed {processed} products into synsets.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "matplotlib>=3.10.3",
+    "openai>=1.59.5",
     "pandas>=2.2.3",
     "pytest>=8.3.5",
     "scikit-learn>=1.6.1",
@@ -14,4 +15,5 @@ dependencies = [
 tagbattle = "padjective.tagbattle:main"
 ranking = "padjective.ranking:main"
 display = "padjective.display:main"
+product_synsets = "padjective.product_synsets:main"
 

--- a/tests/test_build_site_synsets.py
+++ b/tests/test_build_site_synsets.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from padjective.build_site import build_site
+
+
+def _prepare_synset_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE product_synsets (
+                product_id INTEGER PRIMARY KEY,
+                title TEXT NOT NULL,
+                tags TEXT,
+                synset_id TEXT,
+                synset_name TEXT,
+                synset_definition TEXT,
+                confidence REAL,
+                not_found INTEGER NOT NULL,
+                reason TEXT,
+                model TEXT NOT NULL,
+                raw_response TEXT NOT NULL,
+                processed_at TEXT
+            )
+            """
+        )
+        base_time = datetime(2024, 1, 1, 12, 0, 0)
+        rows = [
+            (
+                1,
+                "Widget",
+                "tag1",
+                "n07737745",
+                "banana",
+                "elongated crescent-shaped yellow fruit",
+                0.9,
+                0,
+                "Classic banana gadget",
+                "gpt-5-mini",
+                "{}",
+                (base_time).isoformat(sep=" "),
+            ),
+            (
+                2,
+                "Gadget",
+                "tag2",
+                None,
+                None,
+                None,
+                None,
+                1,
+                "No clear WordNet match",
+                "gpt-5-mini",
+                "{}",
+                (base_time + timedelta(minutes=10)).isoformat(sep=" "),
+            ),
+            (
+                3,
+                "Thingamajig",
+                "tag3",
+                "n03595614",
+                "jersey",
+                "a knit fabric",
+                0.7,
+                0,
+                "Apparel related",
+                "gpt-5-mini",
+                "{}",
+                (base_time + timedelta(minutes=20)).isoformat(sep=" "),
+            ),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO product_synsets (
+                product_id, title, tags, synset_id, synset_name, synset_definition,
+                confidence, not_found, reason, model, raw_response, processed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _prepare_battles_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE battles (winner_tag TEXT, loser_tag TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO battles (winner_tag, loser_tag) VALUES (?, ?)",
+            [("TAG1", "TAG2"), ("TAG1", "TAG3"), ("TAG3", "TAG2")],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_build_site_includes_synset_progress(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("MPLBACKEND", "Agg")
+
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text(
+        "title,tags\nWidget,tag1\nGadget,tag2\nThingamajig,tag3\n",
+        encoding="utf-8",
+    )
+
+    synset_db = tmp_path / "synsets.sqlite"
+    _prepare_synset_db(synset_db)
+
+    battles_db = tmp_path / "battles.sqlite"
+    _prepare_battles_db(battles_db)
+
+    output_dir = tmp_path / "site"
+    metadata = build_site(
+        csv_path,
+        output_dir,
+        precomputed_database=battles_db,
+        synset_db=synset_db,
+    )
+
+    index_html = (output_dir / "index.html").read_text(encoding="utf-8")
+    assert "WordNet synset tagging" in index_html
+    assert "Products classified" in index_html
+    assert "banana" in index_html
+    assert "Recent products without a synset" in index_html
+
+    synset_page = (output_dir / "synsets" / "n07737745.html").read_text(
+        encoding="utf-8"
+    )
+    assert "Widget" in synset_page
+    assert "Classic banana gadget" in synset_page
+
+    assert metadata["synsets"]["processed"] == 3
+    assert metadata["synsets"]["not_found"] == 1
+    assert any(
+        entry["synset_id"] == "n07737745" for entry in metadata["synsets"]["synsets"]
+    )

--- a/tests/test_product_synsets.py
+++ b/tests/test_product_synsets.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from padjective.product_synsets import (
+    CSVProductSource,
+    _extract_tool_response,
+    process_products,
+)
+
+
+def test_csv_product_source_reads_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text("title,tags\nWidget,tag1\nGadget,tag2\n", encoding="utf-8")
+
+    source = CSVProductSource(csv_path)
+    records = list(source.iter_products())
+
+    assert [record.title for record in records] == ["Widget", "Gadget"]
+    assert records[0].product_id == 1
+    assert records[1].product_id == 2
+
+
+def test_extract_tool_response_handles_nested_structure() -> None:
+    payload = {
+        "output": [
+            {
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "function": {
+                            "name": "record_synset",
+                            "arguments": json.dumps(
+                                {
+                                    "synset_id": "n00000000",
+                                    "synset_name": "test",
+                                    "synset_definition": "definition",
+                                    "confidence": 0.5,
+                                    "not_found": False,
+                                }
+                            ),
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+    result = _extract_tool_response(payload)
+    assert result["synset_id"] == "n00000000"
+    assert result["not_found"] is False
+
+
+class MockClient:
+    def __init__(self, response_payload: dict) -> None:
+        self.response_payload = response_payload
+        self.calls = []
+
+    class Responses:
+        def __init__(self, outer: "MockClient") -> None:
+            self.outer = outer
+
+        def create(self, **kwargs):
+            self.outer.calls.append(kwargs)
+            return MockClient._Response(self.outer.response_payload)
+
+    class _Response:
+        def __init__(self, payload: dict) -> None:
+            self.payload = payload
+
+        def model_dump(self) -> dict:
+            return self.payload
+
+    @property
+    def responses(self) -> "MockClient.Responses":
+        return MockClient.Responses(self)
+
+
+def test_process_products_stores_results(tmp_path: Path) -> None:
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text("title,tags\nWidget,tag1\n", encoding="utf-8")
+    db_path = tmp_path / "results.sqlite"
+
+    response_payload = {
+        "output": [
+            {
+                "type": "tool_call",
+                "function": {
+                    "name": "record_synset",
+                    "arguments": json.dumps(
+                        {
+                            "synset_id": "n00001740",
+                            "synset_name": "entity",
+                            "synset_definition": "that which is perceived or known or inferred to have its own distinct existence",
+                            "confidence": 0.1,
+                            "not_found": False,
+                        }
+                    ),
+                },
+            }
+        ]
+    }
+    client = MockClient(response_payload)
+
+    processed = process_products(
+        csv_path=csv_path,
+        database_path=db_path,
+        batch_size=1,
+        model="gpt-5-mini",
+        client=client,
+    )
+
+    assert processed == 1
+
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute(
+            "SELECT product_id, synset_id, not_found FROM product_synsets"
+        )
+        row = cursor.fetchone()
+        assert row[0] == 1
+        assert row[1] == "n00001740"
+        assert row[2] == 0
+
+
+@pytest.mark.parametrize("invalid_batch", [0, -5])
+def test_process_products_validates_batch_size(tmp_path: Path, invalid_batch: int) -> None:
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text("title,tags\nWidget,tag1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        process_products(
+            csv_path=csv_path,
+            database_path=tmp_path / "db.sqlite",
+            batch_size=invalid_batch,
+            model="gpt-5-mini",
+            client=MockClient({"output": []}),
+        )


### PR DESCRIPTION
## Summary
- add WordNet synset progress metrics, recent "not found" samples, and a top-synsets table to the static site homepage while wiring metadata for downstream use
- aggregate classification stats from the SQLite results, compute throughput projections, and emit dedicated per-synset detail pages alongside an overview index
- plumb the synset database path through the cron job and cover the site builder changes with an end-to-end regression test

## Testing
- `uv run -m pytest -q` *(fails: unable to download pinned dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f3ea9e048325ab2974abc1c6b5d8