### PR TITLE
Add tool name to synset function spec

### DIFF
--- a/padjective/product_synsets.py
+++ b/padjective/product_synsets.py
@@ -146,6 +146,7 @@ def _build_tool_spec() -> Dict[str, object]:
 
     return {
         "type": "function",
+        "name": "record_synset",
         "function": {
             "name": "record_synset",
             "description": (


### PR DESCRIPTION
## Summary
- add a top-level name to the record_synset tool specification so the Responses API receives the required field

## Testing
- uv run -m pytest -q *(fails: unable to download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b03307908325a4ff197ba733f1c9