### PR TITLE
Log full response when synset tool call missing

### DIFF
--- a/padjective/product_synsets.py
+++ b/padjective/product_synsets.py
@@ -247,7 +247,16 @@ def _extract_tool_response(response_dict: Dict[str, object]) -> Dict[str, object
                     arguments = _parse_tool_arguments(content_item)
                     if arguments is not None:
                         return arguments
-    raise ValueError("No tool call found in model response")
+    try:
+        serialized_response = json.dumps(
+            response_dict, ensure_ascii=False, indent=2, sort_keys=True
+        )
+    except (TypeError, ValueError):  # pragma: no cover - fallback for unexpected types
+        serialized_response = repr(response_dict)
+    raise ValueError(
+        "No tool call found in model response. Full response:\n"
+        f"{serialized_response}"
+    )
 
 
 def call_synset_model(client: "OpenAI", product: ProductRecord, *, model: str) -> SynsetResult:


### PR DESCRIPTION
## Summary
- include the serialized model response in the error raised when no tool call is present

## Testing
- uv run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9cea601c0832583187f82f1cfa669