### PR TITLE
Handle OpenAI function_call responses in synset pipeline

### DIFF
--- a/padjective/product_synsets.py
+++ b/padjective/product_synsets.py
@@ -219,6 +219,10 @@ def _extract_tool_response(response_dict: Dict[str, object]) -> Dict[str, object
         if not isinstance(item, dict):
             continue
         item_type = item.get("type")
+        if item_type == "function_call":
+            arguments = _parse_tool_arguments(item)
+            if arguments is not None:
+                return arguments
         if item_type == "tool_call":
             function = item.get("function", {})
             if not isinstance(function, dict):

--- a/tests/test_product_synsets.py
+++ b/tests/test_product_synsets.py
@@ -83,6 +83,30 @@ def test_extract_tool_response_handles_tool_use_content() -> None:
     assert result["confidence"] == 0.8
 
 
+def test_extract_tool_response_handles_function_call_items() -> None:
+    payload = {
+        "output": [
+            {
+                "type": "function_call",
+                "name": "record_synset",
+                "arguments": json.dumps(
+                    {
+                        "synset_id": "n01234567",
+                        "synset_name": "gizmo",
+                        "synset_definition": "a made-up gadget",
+                        "confidence": 0.3,
+                        "not_found": False,
+                    }
+                ),
+            }
+        ]
+    }
+
+    result = _extract_tool_response(payload)
+    assert result["synset_definition"] == "a made-up gadget"
+    assert result["confidence"] == 0.3
+
+
 class MockClient:
     def __init__(self, response_payload: dict) -> None:
         self.response_payload = response_payload


### PR DESCRIPTION
## Summary
- treat OpenAI `function_call` response items as valid tool payloads when parsing synset responses
- add regression test covering function_call-only responses to ensure extraction works

## Testing
- uv run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9d4862d048325a03116ea33f1179d