### PR TITLE
Handle missing synset ids gracefully

### DIFF
--- a/padjective/product_synsets.py
+++ b/padjective/product_synsets.py
@@ -304,10 +304,15 @@ def call_synset_model(client: "OpenAI", product: ProductRecord, *, model: str) -
 
     if not not_found:
         if not synset_id:
-            raise ValueError("Model indicated a synset was found but no synset_id was provided")
-        if confidence is not None and not isinstance(confidence, (int, float)):
+            not_found = True
+            missing_reason = (
+                "Model response indicated a synset was found but did not include a synset_id."
+            )
+            reason = f"{reason}\n{missing_reason}" if reason else missing_reason
+        elif confidence is not None and not isinstance(confidence, (int, float)):
             raise ValueError("Confidence value must be numeric when provided")
-    else:
+
+    if not_found:
         synset_id = None
         synset_name = None
         synset_definition = None
@@ -319,7 +324,7 @@ def call_synset_model(client: "OpenAI", product: ProductRecord, *, model: str) -
         synset_definition=synset_definition,
         confidence=float(confidence) if isinstance(confidence, (int, float)) else None,
         not_found=not_found,
-        reason=tool_payload.get("reason"),
+        reason=reason,
         raw_response=json.dumps(response_dict),
     )
 

--- a/tests/test_product_synsets.py
+++ b/tests/test_product_synsets.py
@@ -8,7 +8,9 @@ import pytest
 
 from padjective.product_synsets import (
     CSVProductSource,
+    ProductRecord,
     _extract_tool_response,
+    call_synset_model,
     process_products,
 )
 
@@ -131,6 +133,40 @@ class MockClient:
     def responses(self) -> "MockClient.Responses":
         return MockClient.Responses(self)
 
+
+def test_call_synset_model_handles_missing_synset_id() -> None:
+    response_payload = {
+        "output": [
+            {
+                "type": "tool_call",
+                "function": {
+                    "name": "record_synset",
+                    "arguments": json.dumps(
+                        {
+                            "synset_name": "widget",
+                            "synset_definition": "a placeholder item",
+                            "confidence": 0.6,
+                            "not_found": False,
+                            "reason": "Model forgot the id",
+                        }
+                    ),
+                },
+            }
+        ]
+    }
+    client = MockClient(response_payload)
+    product = ProductRecord(product_id=1, title="Widget", tags="example")
+
+    result = call_synset_model(client, product, model="gpt-5-mini")
+
+    assert result.not_found is True
+    assert result.synset_id is None
+    assert result.reason is not None
+    assert "Model forgot the id" in result.reason
+    assert (
+        "Model response indicated a synset was found but did not include a synset_id."
+        in result.reason
+    )
 
 def test_process_products_stores_results(tmp_path: Path) -> None:
     csv_path = tmp_path / "products.csv"


### PR DESCRIPTION
## Summary
- treat model responses that omit a synset identifier as not-found cases while preserving diagnostic context
- add a regression test covering the missing-synset-id scenario for call_synset_model

## Testing
- uv run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9dfe05afc8325982aac20d66d888f