### PR TITLE
Refactor tag pipeline to use Shopify Postgres

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,15 @@ The real goal is to work with a full data set (products.csv) which is 1000 times
 
 ---
 
+⚠️ **Process data directly from Shopify Postgres**
+
+We no longer read from CSV files or SQLite databases. Always pull product data
+from the Shopify stores Postgres database and persist results to the
+`padjective` schema in that same database (use the default `pg_default`
+tablespace explicitly when creating objects).
+
+---
+
 If CLAUDE.md is present, read it.
 
 Run the unit tests with `uv run -m pytest -q`.

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ tags where they generally appear at the same depth, and ultimately assign an int
 
 (Named tagbattle in honour of kittenwar, a very addictive website.)
 
-For each product:
+For each product retrieved from the Shopify stores Postgres database:
  - For each tag, we look to see if the tag is a subset of another tag in that same product line. e.g. if the tags are "chocolate,milk chocolate" then we ignore chocolate
    and only work with milk chocolate
- - If the title has a " - " in it (a dash surrounded by whitespace), then we pretend that we have two separate titles. e.g. If we have "Easter bunny - milk chocolate" 
+ - If the title has a " - " in it (a dash surrounded by whitespace), then we pretend that we have two separate titles. e.g. If we have "Easter bunny - milk chocolate"
    then we don't say that milk comes after Easter. We just don't know the relationship between Easter and milk from this example
  - For each title:
    - We determine where the tag appears in the title, i.e. which character in the title is the start of the tag using a case-insensitive search. For many tags the answer
      will be "nowhere"
    - For each pair of tags which are somewhere in the title, record which one came first. Pretend that it's a competition, and record which tag won and which tag lost into
-     a sqlite database table
+     the ``padjective.battles`` table (created on the ``pg_default`` tablespace)
 
 ## ranking.py
  
-Use the choix library and the sqlite database from tagbattle.py to produce ranking tables for each tag.
+Use the choix library and the Postgres ``padjective.battles`` table from tagbattle.py to produce ranking tables for each tag and persist them in ``padjective.tag_rankings``.
 
 ## display.py
 
@@ -55,15 +55,15 @@ defaults provided in the repository:
 # install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# process the sample data
-uv run padjective/tagbattle.py
+# process the Shopify data (requires SHOPIFY_DB_DSN or DATABASE_URL)
+uv run padjective/tagbattle.py --taxonomy-table cantbuymelove.product_taxonony --product-view cantbuymelove.product
 uv run padjective/ranking.py
 uv run padjective/display.py
 ```
 
-This will create ``battles.sqlite`` from ``products_point_one_percent_sample.csv``,
-produce ``tag_rankings.csv`` and render ``tag_rankings.html`` and
-``tag_rankings.png``.
+This sequence populates ``padjective.battles`` and ``padjective.tag_rankings``
+inside the Shopify stores Postgres database and renders ``tag_rankings.html``
+and ``tag_rankings.png`` locally.
 
 ## Training a synset classifier
 

--- a/padjective/db.py
+++ b/padjective/db.py
@@ -1,0 +1,97 @@
+"""Utilities for interacting with the Shopify Postgres database."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Tuple
+
+import psycopg
+from psycopg import sql
+
+
+def get_connection(dsn: str | None = None) -> psycopg.Connection:
+    """Return a psycopg connection using ``dsn`` or environment defaults.
+
+    The function checks the ``SHOPIFY_DB_DSN`` environment variable first and
+    then falls back to ``DATABASE_URL``. A missing DSN results in a
+    ``RuntimeError`` with a helpful message so that callers can surface the
+    configuration problem early.
+    """
+
+    effective_dsn = dsn or os.getenv("SHOPIFY_DB_DSN") or os.getenv("DATABASE_URL")
+    if not effective_dsn:
+        raise RuntimeError(
+            "Provide a Postgres DSN via --dsn, SHOPIFY_DB_DSN, or DATABASE_URL"
+        )
+    return psycopg.connect(effective_dsn)
+
+
+def _split_qualified_name(name: str) -> Tuple[str, str]:
+    parts = name.split(".")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(
+            f"Expected a fully qualified identifier in the form schema.table, got {name!r}"
+        )
+    return parts[0], parts[1]
+
+
+def qualified_identifier(name: str) -> sql.Identifier:
+    """Return a safe SQL identifier for ``schema.table`` strings."""
+
+    schema, table = _split_qualified_name(name)
+    return sql.Identifier(schema, table)
+
+
+def ensure_schema(conn: psycopg.Connection, schema: str) -> None:
+    """Create ``schema`` if it does not yet exist."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("CREATE SCHEMA IF NOT EXISTS {schema}").format(
+                schema=sql.Identifier(schema)
+            )
+        )
+    conn.commit()
+
+
+def ensure_table(
+    conn: psycopg.Connection,
+    schema: str,
+    table: str,
+    columns_sql: Iterable[str],
+    indexes_sql: Iterable[str] | None = None,
+) -> None:
+    """Ensure a table exists using the provided column and index SQL fragments."""
+
+    column_block = ",\n".join(columns_sql)
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {schema}.{table} (
+                    {columns}
+                ) TABLESPACE pg_default
+                """
+            ).format(
+                schema=sql.Identifier(schema),
+                table=sql.Identifier(table),
+                columns=sql.SQL(column_block),
+            )
+        )
+        if indexes_sql:
+            for statement in indexes_sql:
+                cur.execute(statement)
+    conn.commit()
+
+
+def truncate_table(conn: psycopg.Connection, schema: str, table: str) -> None:
+    """Remove all rows from ``schema.table``."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("TRUNCATE TABLE {schema}.{table}").format(
+                schema=sql.Identifier(schema),
+                table=sql.Identifier(table),
+            )
+        )
+    conn.commit()

--- a/padjective/display.py
+++ b/padjective/display.py
@@ -1,14 +1,16 @@
 import argparse
 from pathlib import Path
 
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
+from psycopg import sql
+
+from . import db
 
 
 def generate_outputs(
-    csv_path: Path, html_path: Path, image_path: Path, rows: int = 10
+    df: pd.DataFrame, html_path: Path, image_path: Path, rows: int = 10
 ) -> None:
-    df = pd.read_csv(csv_path)
     df_sorted = df.sort_values("score", ascending=False)
 
     # Print selected rows to stdout
@@ -33,13 +35,28 @@ def generate_outputs(
     plt.close()
 
 
+def load_rankings(conn, schema: str, table: str) -> pd.DataFrame:
+    query = sql.SQL(
+        "SELECT tag, component, score FROM {schema}.{table} ORDER BY component, score DESC"
+    ).format(schema=sql.Identifier(schema), table=sql.Identifier(table))
+    return pd.read_sql_query(query, conn)
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Display tag ranking results.")
+    parser = argparse.ArgumentParser(description="Display tag ranking results from Postgres.")
     parser.add_argument(
-        "--rankings",
-        type=Path,
-        default=Path("tag_rankings.csv"),
-        help="CSV file produced by ranking.py",
+        "--dsn",
+        help="Postgres DSN. Defaults to SHOPIFY_DB_DSN or DATABASE_URL if unset.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="padjective",
+        help="Schema containing the rankings table.",
+    )
+    parser.add_argument(
+        "--table",
+        default="tag_rankings",
+        help="Table name holding the rankings data.",
     )
     parser.add_argument(
         "--html",
@@ -60,7 +77,11 @@ def main() -> None:
         help="Number of rows to print to stdout (0 for all)",
     )
     args = parser.parse_args()
-    generate_outputs(args.rankings, args.html, args.image, args.rows)
+
+    conn = db.get_connection(args.dsn)
+    df = load_rankings(conn, args.schema, args.table)
+    generate_outputs(df, args.html, args.image, args.rows)
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/padjective/ranking.py
+++ b/padjective/ranking.py
@@ -1,9 +1,10 @@
 import argparse
-import sqlite3
-from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Sequence, Tuple
 
 import pandas as pd
+from psycopg import sql
+
+from . import db
 
 
 def _elo_scores(num_tags: int, data: List[Tuple[int, int]], k: float = 32.0) -> List[float]:
@@ -20,14 +21,17 @@ def _elo_scores(num_tags: int, data: List[Tuple[int, int]], k: float = 32.0) -> 
     return ratings
 
 
-def load_pairs(db_path: Path) -> List[Tuple[str, str]]:
-    """Load winner/loser pairs from the database."""
-    conn = sqlite3.connect(db_path)
-    cur = conn.cursor()
-    cur.execute("SELECT winner_tag, loser_tag FROM battles")
-    pairs = cur.fetchall()
-    conn.close()
-    return pairs
+def load_pairs(conn, schema: str) -> List[Tuple[str, str]]:
+    """Load winner/loser pairs from Postgres."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("SELECT winner_tag, loser_tag FROM {schema}.battles").format(
+                schema=sql.Identifier(schema)
+            )
+        )
+        rows = cur.fetchall()
+    return [(winner, loser) for winner, loser in rows]
 
 
 def _connected_components(graph: Dict[str, List[str]]) -> List[List[str]]:
@@ -92,28 +96,57 @@ def compute_rankings(pairs: List[Tuple[str, str]]) -> pd.DataFrame:
     return df.sort_values(["component", "score"], ascending=[True, False]).reset_index(drop=True)
 
 
-def save_rankings(df: pd.DataFrame, csv_path: Path) -> None:
-    df.to_csv(csv_path, index=False)
+def ensure_output_table(conn, schema: str, table: str) -> None:
+    columns = (
+        "tag TEXT PRIMARY KEY",
+        "component INTEGER NOT NULL",
+        "score DOUBLE PRECISION NOT NULL",
+        "updated_at TIMESTAMPTZ NOT NULL DEFAULT now()",
+    )
+    indexes: Sequence[sql.SQL] = ()
+    db.ensure_table(conn, schema, table, columns, indexes)
+
+
+def save_rankings(conn, schema: str, table: str, df: pd.DataFrame) -> None:
+    ensure_output_table(conn, schema, table)
+    db.truncate_table(conn, schema, table)
+    records = list(df[["tag", "component", "score"]].itertuples(index=False, name=None))
+    if not records:
+        return
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            sql.SQL(
+                "INSERT INTO {schema}.{table} (tag, component, score) VALUES (%s, %s, %s)"
+            ).format(schema=sql.Identifier(schema), table=sql.Identifier(table)),
+            records,
+        )
+    conn.commit()
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Compute tag rankings from battle data.")
+    parser = argparse.ArgumentParser(description="Compute tag rankings from Postgres battle data.")
     parser.add_argument(
-        "--database",
-        type=Path,
-        default=Path("battles.sqlite"),
-        help="SQLite database produced by tagbattle.py",
+        "--dsn",
+        help="Postgres DSN. Defaults to SHOPIFY_DB_DSN or DATABASE_URL if unset.",
     )
     parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("tag_rankings.csv"),
-        help="CSV file to write tag rankings to",
+        "--schema",
+        default="padjective",
+        help="Schema containing battle inputs and the output table.",
+    )
+    parser.add_argument(
+        "--output-table",
+        default="tag_rankings",
+        help="Name of the table (within schema) to store rankings in.",
     )
     args = parser.parse_args()
-    pairs = load_pairs(args.database)
+
+    conn = db.get_connection(args.dsn)
+    pairs = load_pairs(conn, args.schema)
     df = compute_rankings(pairs)
-    save_rankings(df, args.output)
+    save_rankings(conn, args.schema, args.output_table, df)
+    conn.close()
 
 
 if __name__ == "__main__":

--- a/padjective/tagbattle.py
+++ b/padjective/tagbattle.py
@@ -3,11 +3,22 @@
 from __future__ import annotations
 
 import argparse
-import csv
-import sqlite3
-import sys
-from pathlib import Path
-from typing import Dict, Iterable, List
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+from psycopg import sql
+from psycopg.rows import dict_row
+
+from . import db
+
+
+@dataclass(frozen=True)
+class Battle:
+    """Simple container representing a pairwise comparison."""
+
+    product_id: int | None
+    winner_tag: str
+    loser_tag: str
 
 
 def filter_nested_tags(tags: Iterable[str]) -> List[str]:
@@ -16,6 +27,7 @@ def filter_nested_tags(tags: Iterable[str]) -> List[str]:
     Tags are compared case-insensitively and returned in their original order
     without duplicates.
     """
+
     unique: List[str] = []
     seen = set()
     for tag in tags:
@@ -39,6 +51,7 @@ def filter_nested_tags(tags: Iterable[str]) -> List[str]:
 
 def split_title(title: str) -> List[str]:
     """Split a product title on ``" - "`` if present."""
+
     return [part.strip() for part in title.split(" - ")]
 
 
@@ -48,6 +61,7 @@ def tag_positions(title: str, tags: Iterable[str]) -> Dict[str, int]:
     The search is case-insensitive and only the first occurrence is recorded.
     Tags that are not present are omitted from the result.
     """
+
     lower_title = title.lower()
     positions: Dict[str, int] = {}
     for tag in tags:
@@ -57,70 +71,163 @@ def tag_positions(title: str, tags: Iterable[str]) -> Dict[str, int]:
     return positions
 
 
-def record_battles(positions: Dict[str, int], cursor: sqlite3.Cursor) -> None:
-    """Record pairwise ordering of tags into the ``battles`` table."""
-    tags = list(positions.keys())
-    for i in range(len(tags)):
-        for j in range(i + 1, len(tags)):
-            t1, t2 = tags[i], tags[j]
-            if positions[t1] == positions[t2]:
-                continue
-            if positions[t1] < positions[t2]:
-                winner, loser = t1.upper(), t2.upper()
-            else:
-                winner, loser = t2.upper(), t1.upper()
-            cursor.execute(
-                "INSERT INTO battles (winner_tag, loser_tag) VALUES (?, ?)",
-                (winner, loser),
-            )
+def build_battles(title: str, tag_string: str) -> List[Tuple[str, str]]:
+    """Return ordered tag pairs derived from ``title`` and ``tag_string``."""
 
-
-def process_product(title: str, tag_string: str, cursor: sqlite3.Cursor) -> None:
-    """Process a single product title and tag list."""
     tags = [t.strip() for t in tag_string.split(",") if t.strip()]
     tags = [t.upper() for t in filter_nested_tags(tags)]
+    pairs: List[Tuple[str, str]] = []
     for part in split_title(title):
         positions = tag_positions(part, tags)
         if len(positions) < 2:
             continue
-        record_battles(positions, cursor)
+        ordered_tags = list(positions.keys())
+        for i in range(len(ordered_tags)):
+            for j in range(i + 1, len(ordered_tags)):
+                t1, t2 = ordered_tags[i], ordered_tags[j]
+                if positions[t1] == positions[t2]:
+                    continue
+                if positions[t1] < positions[t2]:
+                    pairs.append((t1, t2))
+                else:
+                    pairs.append((t2, t1))
+    return pairs
 
 
-def process_csv(csv_path: Path, sqlite_path: Path) -> None:
-    """Process ``csv_path`` and store results in ``sqlite_path``."""
-    conn = sqlite3.connect(str(sqlite_path))
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS battles (winner_tag TEXT, loser_tag TEXT)"
+def ensure_storage(conn, schema: str) -> None:
+    """Ensure the ``padjective`` schema and ``battles`` table exist."""
+
+    db.ensure_schema(conn, schema)
+    battle_columns = (
+        "product_id BIGINT",
+        "winner_tag TEXT NOT NULL",
+        "loser_tag TEXT NOT NULL",
+        "recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()",
     )
-    # Allow very large fields for datasets with massive tag columns
-    csv.field_size_limit(sys.maxsize)
-    with open(csv_path, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            process_product(row["title"], row.get("tags", ""), cur)
+    indexes = (
+        sql.SQL(
+            "CREATE INDEX IF NOT EXISTS {schema}_battles_winner_idx "
+            "ON {schema}.battles (winner_tag) TABLESPACE pg_default"
+        ).format(schema=sql.Identifier(schema)),
+        sql.SQL(
+            "CREATE INDEX IF NOT EXISTS {schema}_battles_loser_idx "
+            "ON {schema}.battles (loser_tag) TABLESPACE pg_default"
+        ).format(schema=sql.Identifier(schema)),
+    )
+    db.ensure_table(conn, schema, "battles", battle_columns, indexes_sql=indexes)
+
+
+def insert_battles(conn, schema: str, battles: Sequence[Battle]) -> None:
+    """Persist a batch of ``Battle`` objects to Postgres."""
+
+    if not battles:
+        return
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            sql.SQL(
+                "INSERT INTO {schema}.battles (product_id, winner_tag, loser_tag) "
+                "VALUES (%s, %s, %s)"
+            ).format(schema=sql.Identifier(schema)),
+            [(b.product_id, b.winner_tag, b.loser_tag) for b in battles],
+        )
     conn.commit()
+
+
+def stream_products(conn, taxonomy_table: str, product_view: str):
+    """Yield product rows filtered by entries in the taxonomy table."""
+
+    taxonomy_identifier = db.qualified_identifier(taxonomy_table)
+    product_identifier = db.qualified_identifier(product_view)
+    query = sql.SQL(
+        """
+        WITH selected_products AS (
+            SELECT DISTINCT product_id
+            FROM {taxonomy}
+        )
+        SELECT p.id, p.title, p.tags
+        FROM {products} AS p
+        JOIN selected_products sp ON sp.product_id = p.id
+        WHERE p.title IS NOT NULL
+        ORDER BY p.id
+        """
+    ).format(taxonomy=taxonomy_identifier, products=product_identifier)
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(query)
+        for row in cur:
+            yield row
+
+
+def process_database(
+    dsn: str | None,
+    schema: str,
+    taxonomy_table: str,
+    product_view: str,
+    batch_size: int = 1000,
+) -> None:
+    """Stream Shopify data and populate the battles table."""
+
+    conn = db.get_connection(dsn)
+    ensure_storage(conn, schema)
+
+    buffer: List[Battle] = []
+    for row in stream_products(conn, taxonomy_table, product_view):
+        title = row.get("title") or ""
+        tag_string = row.get("tags") or ""
+        product_id = row.get("id")
+        for winner, loser in build_battles(title, tag_string):
+            buffer.append(Battle(product_id=product_id, winner_tag=winner, loser_tag=loser))
+        if len(buffer) >= batch_size:
+            insert_battles(conn, schema, buffer)
+            buffer.clear()
+
+    if buffer:
+        insert_battles(conn, schema, buffer)
+
     conn.close()
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Analyze tag ordering within product titles."
+        description="Analyze tag ordering within product titles using Postgres data."
     )
     parser.add_argument(
-        "--csv",
-        type=Path,
-        default=Path("products_point_one_percent_sample.csv"),
-        help="CSV file containing 'title' and 'tags' columns",
+        "--dsn",
+        help=(
+            "Postgres DSN for the Shopify stores database. If omitted, the script "
+            "uses SHOPIFY_DB_DSN or DATABASE_URL."
+        ),
     )
     parser.add_argument(
-        "--database",
-        type=Path,
-        default=Path("battles.sqlite"),
-        help="SQLite database to store pair results",
+        "--schema",
+        default="padjective",
+        help="Destination schema for derived tables.",
+    )
+    parser.add_argument(
+        "--taxonomy-table",
+        default="cantbuymelove.product_taxonony",
+        help="Qualified taxonomy table to select product IDs from.",
+    )
+    parser.add_argument(
+        "--product-view",
+        default="cantbuymelove.product",
+        help="Qualified product view containing titles and tags.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=2000,
+        help="Number of comparisons to buffer before writing to Postgres.",
     )
     args = parser.parse_args()
-    process_csv(args.csv, args.database)
+    process_database(
+        dsn=args.dsn,
+        schema=args.schema,
+        taxonomy_table=args.taxonomy_table,
+        product_view=args.product_view,
+        batch_size=args.batch_size,
+    )
 
 
 if __name__ == "__main__":

--- a/padjective/tagbattle.py
+++ b/padjective/tagbattle.py
@@ -106,13 +106,19 @@ def ensure_storage(conn, schema: str) -> None:
     )
     indexes = (
         sql.SQL(
-            "CREATE INDEX IF NOT EXISTS {schema}_battles_winner_idx "
+            "CREATE INDEX IF NOT EXISTS {index} "
             "ON {schema}.battles (winner_tag) TABLESPACE pg_default"
-        ).format(schema=sql.Identifier(schema)),
+        ).format(
+            index=sql.Identifier(f"{schema}_battles_winner_idx"),
+            schema=sql.Identifier(schema),
+        ),
         sql.SQL(
-            "CREATE INDEX IF NOT EXISTS {schema}_battles_loser_idx "
+            "CREATE INDEX IF NOT EXISTS {index} "
             "ON {schema}.battles (loser_tag) TABLESPACE pg_default"
-        ).format(schema=sql.Identifier(schema)),
+        ).format(
+            index=sql.Identifier(f"{schema}_battles_loser_idx"),
+            schema=sql.Identifier(schema),
+        ),
     )
     db.ensure_table(conn, schema, "battles", battle_columns, indexes_sql=indexes)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "matplotlib>=3.10.3",
     "openai>=1.59.5",
     "pandas>=2.2.3",
+    "psycopg[binary]>=3.2.3",
     "pytest>=8.3.5",
     "scikit-learn>=1.6.1",
     "tqdm>=4.67.1",

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -4,18 +4,15 @@ from pathlib import Path
 from padjective.display import generate_outputs
 
 
-def _make_csv(tmp_path: Path) -> Path:
-    df = pd.DataFrame({"tag": ["A", "B", "C"], "score": [3, 2, 1]})
-    csv = tmp_path / "rankings.csv"
-    df.to_csv(csv, index=False)
-    return csv
+def _make_dataframe() -> pd.DataFrame:
+    return pd.DataFrame({"tag": ["A", "B", "C"], "score": [3, 2, 1], "component": [0, 0, 0]})
 
 
 def test_generate_outputs_truncated(tmp_path, capsys):
-    csv = _make_csv(tmp_path)
+    df = _make_dataframe()
     html = tmp_path / "out.html"
     img = tmp_path / "plot.png"
-    generate_outputs(csv, html, img, rows=2)
+    generate_outputs(df, html, img, rows=2)
     out_lines = capsys.readouterr().out.strip().splitlines()
     # header plus two rows
     assert len(out_lines) == 3
@@ -24,10 +21,10 @@ def test_generate_outputs_truncated(tmp_path, capsys):
 
 
 def test_generate_outputs_all(tmp_path, capsys):
-    csv = _make_csv(tmp_path)
+    df = _make_dataframe()
     html = tmp_path / "out_all.html"
     img = tmp_path / "plot_all.png"
-    generate_outputs(csv, html, img, rows=0)
+    generate_outputs(df, html, img, rows=0)
     out_lines = capsys.readouterr().out.strip().splitlines()
     # header plus three rows
     assert len(out_lines) == 4

--- a/tests/test_tagbattle.py
+++ b/tests/test_tagbattle.py
@@ -1,10 +1,8 @@
-import sqlite3
-
 from padjective.tagbattle import (
     filter_nested_tags,
     split_title,
     tag_positions,
-    process_product,
+    build_battles,
 )
 
 
@@ -23,12 +21,6 @@ def test_tag_positions():
     assert pos == {"red": 5, "shoe": 9}
 
 
-def test_process_product_inserts_pairs():
-    conn = sqlite3.connect(":memory:")
-    cur = conn.cursor()
-    cur.execute("CREATE TABLE battles (winner_tag TEXT, loser_tag TEXT)")
-    process_product("big bunny milk chocolate", "bunny,milk chocolate", cur)
-    cur.execute("SELECT winner_tag, loser_tag FROM battles")
-    rows = cur.fetchall()
-    assert rows == [("BUNNY", "MILK CHOCOLATE")]
-    conn.close()
+def test_build_battles_generates_pairs():
+    pairs = build_battles("big bunny milk chocolate", "bunny,milk chocolate")
+    assert pairs == [("BUNNY", "MILK CHOCOLATE")]


### PR DESCRIPTION
## Summary
- add a Postgres helper module and migrate tagbattle to read from Shopify tables and write to padjective.battles
- update ranking and display scripts to consume Postgres data and persist results in padjective.tag_rankings
- document the new workflow, add psycopg dependency, and adjust unit tests for the revised interfaces

## Testing
- `uv run -m pytest -q` *(fails: network error while downloading psycopg)*

------
https://chatgpt.com/codex/tasks/task_e_68e1369205708325923037ef37054ec8