### PR TITLE
Remove CSV/SQLite support from ranking workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ tasks and stores the outcomes in ``holdout_tasks.sqlite`` by default.
 # create (or extend) a task queue of 5,000 random splits
 uv run -m padjective.experiments init --total 5000 --test-fraction 0.2
 
-# execute up to 250 pending tasks using an existing battles database
+# execute up to 250 pending tasks against Postgres battle data
 uv run -m padjective.experiments run \
-    --database battles.sqlite \
+    --dsn "$SHOPIFY_DB_DSN" \
     --tasks-db holdout_tasks.sqlite \
     --take 250
 

--- a/padjective/build_site.py
+++ b/padjective/build_site.py
@@ -10,11 +10,11 @@ import shutil
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 
 import pandas as pd
 
-from . import display, experiments, ranking, tagbattle
+from . import db, display, experiments, ranking, tagbattle
 
 
 def _ensure_clean_directory(path: Path) -> None:
@@ -38,25 +38,20 @@ def _collect_tag_stats(csv_path: Path) -> Dict[str, int]:
     return {"products": total_products, "unique_tags": len(unique_tags)}
 
 
-def _count_battles(db_path: Path) -> int:
-    conn = sqlite3.connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM battles")
-        (count,) = cursor.fetchone()
-        return int(count)
-    finally:
-        conn.close()
+def _count_battles(pairs: Sequence[Tuple[str, str]]) -> int:
+    return len(pairs)
 
 
-def _write_sql_dump(db_path: Path, dump_path: Path) -> None:
-    conn = sqlite3.connect(db_path)
-    try:
-        with dump_path.open("w", encoding="utf-8") as dump_file:
-            for line in conn.iterdump():
-                dump_file.write(f"{line}\n")
-    finally:
-        conn.close()
+def _write_sql_dump(pairs: Sequence[Tuple[str, str]], dump_path: Path, schema: str) -> None:
+    with dump_path.open("w", encoding="utf-8") as dump_file:
+        dump_file.write("BEGIN;\n")
+        for winner, loser in pairs:
+            safe_winner = winner.replace("'", "''")
+            safe_loser = loser.replace("'", "''")
+            dump_file.write(
+                f"INSERT INTO {schema}.battles (winner_tag, loser_tag) VALUES ('{safe_winner}', '{safe_loser}');\n"
+            )
+        dump_file.write("COMMIT;\n")
 
 
 def _build_index_html(
@@ -65,7 +60,6 @@ def _build_index_html(
     leaderboard: pd.DataFrame,
     chart_path: Path,
     artifact_links: Dict[str, Path],
-    source_csv: Path,
     experiments_summary: Optional[Dict[str, Any]] = None,
     synset_summary: Optional[Dict[str, Any]] = None,
 ) -> None:
@@ -368,7 +362,7 @@ def _build_index_html(
   {experiments_block}
 
   <footer>
-    <p>Built from <code>{source_csv.name}</code>. Source available on <a href=\"https://github.com/IFost-Sydney-Uni/padjective\">GitHub</a>.</p>
+    <p>Rankings sourced from the Shopify Postgres battle records. Source available on <a href=\"https://github.com/IFost-Sydney-Uni/padjective\">GitHub</a>.</p>
   </footer>
 </body>
 </html>
@@ -750,7 +744,8 @@ def build_site(
     csv_path: Path,
     output_dir: Path,
     *,
-    precomputed_database: Optional[Path] = None,
+    precomputed_database: Optional[Any] = None,
+    battle_schema: str = "padjective",
     tasks_db: Optional[Path] = None,
     synset_db: Optional[Path] = None,
 ) -> Dict[str, Any]:
@@ -763,40 +758,22 @@ def build_site(
     for path in (assets_dir, downloads_dir, datadumps_dir):
         path.mkdir(parents=True, exist_ok=True)
 
-    db_path = downloads_dir / "battles.sqlite"
+    if precomputed_database is None:
+        raise ValueError("A Postgres connection is required to build the site")
 
-    if precomputed_database is not None:
-        source = precomputed_database.resolve()
-        destination = db_path.resolve()
-        if source != destination:
-            if db_path.exists():
-                db_path.unlink()
-            shutil.copyfile(source, db_path)
-        else:
-            # The precomputed database already matches the expected output path.
-            if not db_path.exists():
-                shutil.copyfile(source, db_path)
-    else:
-        if db_path.exists():
-            db_path.unlink()
-        tagbattle.process_csv(csv_path, db_path)
-
-    pairs = ranking.load_pairs(db_path)
+    pairs = ranking.load_pairs(precomputed_database, battle_schema)
     leaderboard = ranking.compute_rankings(pairs)
-
-    rankings_csv = downloads_dir / "tag_rankings.csv"
-    ranking.save_rankings(leaderboard, rankings_csv)
 
     rankings_html = downloads_dir / "tag_rankings_table.html"
     chart_path = assets_dir / "top_tags.png"
-    display.generate_outputs(rankings_csv, rankings_html, chart_path, rows=20)
+    display.generate_outputs(leaderboard, rankings_html, chart_path, rows=20)
 
     stats = _collect_tag_stats(csv_path)
-    stats["battles"] = _count_battles(db_path)
+    stats["battles"] = _count_battles(pairs)
     stats["components"] = int(leaderboard["component"].nunique()) if not leaderboard.empty else 0
 
     dump_path = datadumps_dir / "battles.sql"
-    _write_sql_dump(db_path, dump_path)
+    _write_sql_dump(pairs, dump_path, battle_schema)
 
     stylesheet = assets_dir / "styles.css"
     stylesheet.write_text(
@@ -879,9 +856,7 @@ table.synset-products tbody tr:nth-child(even) {background: #f8fafc;}
     )
 
     artifact_links: Dict[str, Path] = {
-        "Tag rankings (CSV)": rankings_csv,
         "Tag rankings table (HTML)": rankings_html,
-        "Tag battles database": db_path,
         "SQL dump of battles": dump_path,
         "Top tags chart": chart_path,
     }
@@ -902,14 +877,12 @@ table.synset-products tbody tr:nth-child(even) {background: #f8fafc;}
         leaderboard,
         chart_path,
         artifact_links,
-        csv_path,
         experiments_summary,
         synset_summary,
     )
 
     metadata = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "source_csv": str(csv_path),
         "stats": stats,
         "artifacts": {label: str(path.relative_to(output_dir)) for label, path in artifact_links.items()},
         "experiments": experiments_summary,
@@ -933,10 +906,13 @@ def main() -> None:
         help="Directory where the static site should be written",
     )
     parser.add_argument(
-        "--precomputed-database",
-        type=Path,
-        default=None,
-        help="Optional precomputed battles SQLite database",
+        "--dsn",
+        help="Postgres DSN for reading battles. Uses SHOPIFY_DB_DSN or DATABASE_URL if unset.",
+    )
+    parser.add_argument(
+        "--schema",
+        default="padjective",
+        help="Schema containing battles and output tables.",
     )
     parser.add_argument(
         "--tasks-db",
@@ -952,13 +928,18 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    build_site(
-        args.csv,
-        args.output,
-        precomputed_database=args.precomputed_database,
-        tasks_db=args.tasks_db,
-        synset_db=args.synset_db,
-    )
+    conn = db.get_connection(args.dsn)
+    try:
+        build_site(
+            args.csv,
+            args.output,
+            precomputed_database=conn,
+            battle_schema=args.schema,
+            tasks_db=args.tasks_db,
+            synset_db=args.synset_db,
+        )
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/padjective/experiments.py
+++ b/padjective/experiments.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from . import ranking
+from . import db, ranking
 
 
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
@@ -225,7 +225,8 @@ def _evaluate_holdout(
 def run_tasks(
     *,
     tasks_db: Path,
-    database: Path,
+    database,
+    schema: str = "padjective",
     take: int,
 ) -> List[Dict[str, Any]]:
     """Run up to ``take`` pending tasks against ``database``."""
@@ -233,7 +234,7 @@ def run_tasks(
     if take <= 0:
         return []
 
-    pairs = ranking.load_pairs(database)
+    pairs = ranking.load_pairs(database, schema)
     results: List[Dict[str, Any]] = []
 
     with _connect(tasks_db) as conn:
@@ -376,7 +377,15 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     status_parser = subparsers.add_parser("status", help="Display current task progress")
 
     run_parser = subparsers.add_parser("run", help="Execute pending tasks")
-    run_parser.add_argument("--database", type=Path, required=True, help="SQLite battles database")
+    run_parser.add_argument(
+        "--dsn",
+        help="Postgres DSN. Uses SHOPIFY_DB_DSN or DATABASE_URL if omitted.",
+    )
+    run_parser.add_argument(
+        "--schema",
+        default="padjective",
+        help="Schema containing the battles table.",
+    )
     run_parser.add_argument(
         "--take",
         type=int,
@@ -415,7 +424,16 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
                 args.ensure_total,
                 test_fraction=args.test_fraction,
             )
-        results = run_tasks(tasks_db=args.tasks_db, database=args.database, take=args.take)
+        conn = db.get_connection(args.dsn)
+        try:
+            results = run_tasks(
+                tasks_db=args.tasks_db,
+                database=conn,
+                schema=args.schema,
+                take=args.take,
+            )
+        finally:
+            conn.close()
         if not results:
             print("No pending tasks executed.")
             return

--- a/padjective/ranking.py
+++ b/padjective/ranking.py
@@ -21,10 +21,16 @@ def _elo_scores(num_tags: int, data: List[Tuple[int, int]], k: float = 32.0) -> 
     return ratings
 
 
-def load_pairs(conn, schema: str) -> List[Tuple[str, str]]:
-    """Load winner/loser pairs from Postgres."""
+def load_pairs(source, schema: str | None = None) -> List[Tuple[str, str]]:
+    """Load winner/loser pairs from Postgres or an in-memory sequence."""
 
-    with conn.cursor() as cur:
+    if isinstance(source, Sequence) and not isinstance(source, (str, bytes)):
+        return [(winner, loser) for winner, loser in source]
+
+    if schema is None:
+        raise TypeError("schema is required when loading pairs from a database connection")
+
+    with source.cursor() as cur:
         cur.execute(
             sql.SQL("SELECT winner_tag, loser_tag FROM {schema}.battles").format(
                 schema=sql.Identifier(schema)

--- a/padjective/tagbattle.py
+++ b/padjective/tagbattle.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, Tuple
 
 from psycopg import sql
 from psycopg.rows import dict_row
 
-from . import db
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.append(str(project_root))
+    from padjective import db
+else:
+    from . import db
 
 
 @dataclass(frozen=True)

--- a/tests/test_build_site_synsets.py
+++ b/tests/test_build_site_synsets.py
@@ -87,19 +87,29 @@ def _prepare_synset_db(db_path: Path) -> None:
         conn.close()
 
 
-def _prepare_battles_db(db_path: Path) -> None:
-    conn = sqlite3.connect(db_path)
-    try:
-        conn.execute(
-            "CREATE TABLE battles (winner_tag TEXT, loser_tag TEXT)"
-        )
-        conn.executemany(
-            "INSERT INTO battles (winner_tag, loser_tag) VALUES (?, ?)",
-            [("TAG1", "TAG2"), ("TAG1", "TAG3"), ("TAG3", "TAG2")],
-        )
-        conn.commit()
-    finally:
-        conn.close()
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, _query):
+        return self
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
 
 
 def test_build_site_includes_synset_progress(tmp_path: Path, monkeypatch) -> None:
@@ -114,14 +124,14 @@ def test_build_site_includes_synset_progress(tmp_path: Path, monkeypatch) -> Non
     synset_db = tmp_path / "synsets.sqlite"
     _prepare_synset_db(synset_db)
 
-    battles_db = tmp_path / "battles.sqlite"
-    _prepare_battles_db(battles_db)
+    battle_pairs = [("TAG1", "TAG2"), ("TAG1", "TAG3"), ("TAG3", "TAG2")]
+    battles_conn = _FakeConnection(battle_pairs)
 
     output_dir = tmp_path / "site"
     metadata = build_site(
         csv_path,
         output_dir,
-        precomputed_database=battles_db,
+        precomputed_database=battles_conn,
         synset_db=synset_db,
     )
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,12 +1,34 @@
-import sqlite3
 from pathlib import Path
 
 from padjective import experiments
 
 
-def _make_battles_db(path: Path) -> Path:
-    conn = sqlite3.connect(path)
-    conn.execute("CREATE TABLE battles (winner_tag TEXT, loser_tag TEXT)")
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, _query):
+        return self
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
+
+
+def _make_battles_connection() -> _FakeConnection:
     rows = [
         ("RED", "BLUE"),
         ("RED", "GREEN"),
@@ -14,18 +36,17 @@ def _make_battles_db(path: Path) -> Path:
         ("YELLOW", "GREEN"),
         ("BLUE", "YELLOW"),
     ]
-    conn.executemany("INSERT INTO battles VALUES (?, ?)", rows)
-    conn.commit()
-    conn.close()
-    return path
+    return _FakeConnection(rows)
 
 
 def test_run_tasks_and_status(tmp_path):
-    battles_db = _make_battles_db(tmp_path / "battles.sqlite")
+    battles_conn = _make_battles_connection()
     tasks_db = tmp_path / "tasks.sqlite"
 
     experiments.ensure_tasks(tasks_db, total_tasks=3, test_fraction=0.4)
-    results = experiments.run_tasks(tasks_db=tasks_db, database=battles_db, take=2)
+    results = experiments.run_tasks(
+        tasks_db=tasks_db, database=battles_conn, take=2
+    )
 
     assert len(results) == 2
     status = experiments.task_status(tasks_db)


### PR DESCRIPTION
## Summary
- drop CSV and SQLite handling from the ranking helpers and site builder in favour of Postgres inputs
- update the experiments runner and documentation to use Postgres connections
- refresh unit tests to exercise the new connection-based interfaces

## Testing
- `uv run -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e2d99b81bc8325b406db7cacad8521