### PR TITLE
Update cron script for Postgres tagbattle invocation

### DIFF
--- a/cronscript.sh
+++ b/cronscript.sh
@@ -15,6 +15,11 @@ BATTLES_DB=${PADJECTIVE_BATTLES_DB:-build/battles.sqlite}
 SYNSETS_DB=${PADJECTIVE_SYNSETS_DB:-data/product_synsets.sqlite}
 CLASSIFIER_DB=${PADJECTIVE_CLASSIFIER_DB:-data/synset_classifier.sqlite}
 CLASSIFIER_REPORT_DIR=${PADJECTIVE_CLASSIFIER_REPORT_DIR:-build/synset_classifier}
+TAGBATTLE_SCHEMA=${PADJECTIVE_TAGBATTLE_SCHEMA:-padjective}
+TAGBATTLE_TAXONOMY_TABLE=${PADJECTIVE_TAGBATTLE_TAXONOMY_TABLE:-cantbuymelove.product_taxonony}
+TAGBATTLE_PRODUCT_VIEW=${PADJECTIVE_TAGBATTLE_PRODUCT_VIEW:-cantbuymelove.product}
+TAGBATTLE_BATCH_SIZE=${PADJECTIVE_TAGBATTLE_BATCH_SIZE:-2000}
+SHOPIFY_DSN=${PADJECTIVE_SHOPIFY_DSN:-}
 
 mkdir -p "$(dirname "$TASKS_DB")"
 mkdir -p "$(dirname "$BATTLES_DB")"
@@ -22,7 +27,18 @@ mkdir -p "$(dirname "$SYNSETS_DB")"
 mkdir -p "$(dirname "$CLASSIFIER_DB")"
 mkdir -p "$CLASSIFIER_REPORT_DIR"
 
-uv run padjective/tagbattle.py --csv "$CSV_PATH" --database "$BATTLES_DB"
+if [[ -n "$SHOPIFY_DSN" ]]; then
+    TAGBATTLE_DSN_ARGS=(--dsn "$SHOPIFY_DSN")
+else
+    TAGBATTLE_DSN_ARGS=()
+fi
+
+uv run padjective/tagbattle.py \
+    "${TAGBATTLE_DSN_ARGS[@]}" \
+    --schema "$TAGBATTLE_SCHEMA" \
+    --taxonomy-table "$TAGBATTLE_TAXONOMY_TABLE" \
+    --product-view "$TAGBATTLE_PRODUCT_VIEW" \
+    --batch-size "$TAGBATTLE_BATCH_SIZE"
 uv run -m padjective.experiments --tasks-db "$TASKS_DB" init --total "$TOTAL_TASKS"
 uv run -m padjective.experiments --tasks-db "$TASKS_DB" run --database "$BATTLES_DB" --take "$TASK_BATCH"
 uv run -m padjective.build_site --csv "$CSV_PATH" --output "$OUTPUT_DIR" --precomputed-database "$BATTLES_DB" --tasks-db "$TASKS_DB" --synset-db "$SYNSETS_DB"


### PR DESCRIPTION
## Summary
- add environment overrides for tagbattle schema, taxonomy table, product view, and batch size
- call the updated Postgres-based tagbattle CLI from the cron script, passing the configured options

## Testing
- uv run -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e34906fa448325a8343f1b9f40bd41