### PR TITLE
Fix expected warning noise in benchmark and taxonomy training runs

### DIFF
--- a/padjective/benchmark_runtime.py
+++ b/padjective/benchmark_runtime.py
@@ -18,11 +18,13 @@ import re
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
 import urllib.parse
 import urllib.request
+import warnings
 
 import numpy as np
 import pandas as pd
 from scipy import sparse
 from sklearn.dummy import DummyClassifier
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import f1_score
 from sklearn.neural_network import MLPClassifier
@@ -626,6 +628,13 @@ def _logistic_nonzero_params(model: LogisticRegression) -> float:
     return float(np.count_nonzero(model.coef_) + np.count_nonzero(model.intercept_))
 
 
+def _fit_estimator_quietly(model, features: sparse.csr_matrix, labels: np.ndarray):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
+        model.fit(features, labels)
+    return model
+
+
 def _evaluate_classifier_cv(
     *,
     model_key: str,
@@ -649,8 +658,11 @@ def _evaluate_classifier_cv(
     for fold in folds:
         train_mask = cv_fold_values != fold
         test_mask = cv_fold_values == fold
-        model = make_model()
-        model.fit(features[train_mask], labels[train_mask])
+        model = _fit_estimator_quietly(
+            make_model(),
+            features[train_mask],
+            labels[train_mask],
+        )
         y_true = labels[test_mask]
         y_pred = model.predict(features[test_mask])
         ops = [
@@ -1285,7 +1297,11 @@ def train_levelwise_models(
                 solver="lbfgs",
                 class_weight="balanced",
             )
-            classifier.fit(features[prefix_indices[prefix]], prefix_targets[prefix])
+            classifier = _fit_estimator_quietly(
+                classifier,
+                features[prefix_indices[prefix]],
+                np.asarray(prefix_targets[prefix], dtype=object),
+            )
         models[prefix] = NodeModel(
             prefix=prefix,
             classifier=classifier,
@@ -1643,7 +1659,6 @@ def _build_model_rows(
                 C=1.0,
                 max_iter=DEFAULT_ULR_MAX_ITER,
                 n_jobs=-1,
-                multi_class="multinomial",
                 random_state=42,
             ),
             param_counter=_l1_logistic_nonzero_params,

--- a/padjective/cv.py
+++ b/padjective/cv.py
@@ -75,14 +75,18 @@ def calculate_cv_folds(
     product_table: str = "cantbuymelove.product",
     n_splits: int = 5,
     random_state: int = 42,
+    *,
+    warn_on_fallback: bool = False,
 ) -> Dict[int, int]:
     """Calculate cross-validation fold assignments for products.
 
     Uses :class:`~sklearn.model_selection.StratifiedKFold` to assign each
-    product to a fold, stratifying by taxonomy_path. Products without taxonomy
-    data are excluded from fold assignment. The same ``random_state`` ensures
-    consistency with taxonomy classifier training and other components that
-    rely on deterministic splits.
+    product to a fold, stratifying by taxonomy_path. When the smallest
+    taxonomy bucket cannot support stratification, the helper deterministically
+    falls back to :class:`~sklearn.model_selection.KFold`. Products without
+    taxonomy data are excluded from fold assignment. The same ``random_state``
+    ensures consistency with taxonomy classifier training and other
+    components that rely on deterministic splits.
     """
 
     product_identifier = db.qualified_identifier(product_table)
@@ -132,7 +136,7 @@ def calculate_cv_folds(
     product_ids_array = np.array(product_ids)
     taxonomy_paths_array = np.array(taxonomy_paths, dtype=object)
 
-    unique_labels, counts = np.unique(taxonomy_paths_array, return_counts=True)
+    _, counts = np.unique(taxonomy_paths_array, return_counts=True)
     min_class_size = counts.min() if counts.size else 0
     can_stratify = min_class_size >= n_splits
 
@@ -141,12 +145,13 @@ def calculate_cv_folds(
             n_splits=n_splits, shuffle=True, random_state=random_state
         )
     else:
-        warnings.warn(
-            "Taxonomy distribution too sparse for StratifiedKFold; falling back to "
-            "deterministic KFold splits.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
+        if warn_on_fallback:
+            warnings.warn(
+                "Taxonomy distribution too sparse for StratifiedKFold; falling back to "
+                "deterministic KFold splits.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         cv = KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
 
     fold_assignments: Dict[int, int] = {}

--- a/padjective/taxonomy_pcnn_classifier.py
+++ b/padjective/taxonomy_pcnn_classifier.py
@@ -35,6 +35,7 @@ if __package__ in {None, ""}:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from padjective.torch_runtime import select_torch_device
 else:
     from . import data_access, db, tag_features
     from .metrics import (
@@ -42,6 +43,7 @@ else:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from .torch_runtime import select_torch_device
 
 try:
     from psycopg2 import sql
@@ -348,7 +350,7 @@ def train_nn_classifier(
         train_dataset = dataset
         val_dataset = None
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = select_torch_device()
     model = _build_model(features.shape[1], hidden_layer_sizes, output_dim).to(device)
     optimizer = torch.optim.Adam(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay

--- a/padjective/taxonomy_ulr_classifier.py
+++ b/padjective/taxonomy_ulr_classifier.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import html
 import sys
+import warnings
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +22,7 @@ import numpy as np
 import pandas as pd
 from psycopg import sql
 from scipy import sparse
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import f1_score, make_scorer
 from sklearn.model_selection import StratifiedKFold, cross_validate
@@ -221,7 +223,9 @@ def train_l1_classifier(
         tol=1e-4,
     )
 
-    model.fit(features, labels)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
+        model.fit(features, labels)
     accuracy = float(model.score(features, labels))
 
     num_nonzero, num_total = count_nonzero_params(model)

--- a/padjective/taxonomy_unn_classifier.py
+++ b/padjective/taxonomy_unn_classifier.py
@@ -43,6 +43,7 @@ if __package__ in {None, ""}:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from padjective.torch_runtime import select_torch_device
 else:
     from . import data_access, db
     from .metrics import (
@@ -50,6 +51,7 @@ else:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from .torch_runtime import select_torch_device
 
 
 # Hyperparameters (determined through experimentation)
@@ -246,7 +248,7 @@ def train_unn_classifier(
     if len(unique_labels) < 2:
         raise ValueError("Need at least 2 taxonomies to train")
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = select_torch_device()
 
     # Convert to tensors
     X = torch.from_numpy(features.toarray().astype(np.float32))
@@ -510,7 +512,7 @@ def main() -> None:
     )
 
     # Evaluate on test set
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = select_torch_device()
     model.eval()
 
     X_test = torch.from_numpy(test_features.toarray().astype(np.float32)).to(device)

--- a/padjective/taxonomy_unn_experiment.py
+++ b/padjective/taxonomy_unn_experiment.py
@@ -33,6 +33,7 @@ if __package__ in {None, ""}:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from padjective.torch_runtime import select_torch_device
 else:
     from . import data_access, db
     from .metrics import (
@@ -40,6 +41,7 @@ else:
         ensure_taxonomy_paths_cover_labels,
         hierarchical_loss_score,
     )
+    from .torch_runtime import select_torch_device
 
 from sklearn.metrics import f1_score
 
@@ -208,7 +210,7 @@ def train_and_evaluate(
 ) -> ExperimentResult:
     """Train a model with given config and evaluate on test set."""
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = select_torch_device()
 
     # Convert to tensors
     X_train = torch.from_numpy(train_features.toarray().astype(np.float32))
@@ -536,7 +538,7 @@ def run_pruning_experiment():
     label_encoder = {l: i for i, l in enumerate(unique_labels)}
     label_decoder = {i: l for l, i in label_encoder.items()}
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = select_torch_device()
 
     # Train best model (256 hidden, L1=0.0001)
     print("\nTraining best model configuration: 256 hidden, L1=0.0001...")

--- a/padjective/torch_runtime.py
+++ b/padjective/torch_runtime.py
@@ -1,0 +1,31 @@
+"""Torch runtime helpers that keep CUDA probing quiet on CPU-only hosts."""
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+
+
+_CUDA_INIT_WARNING_RE = r"CUDA initialization: .*"
+
+
+def cuda_is_available() -> bool:
+    """Return whether CUDA can be used without surfacing probe warnings."""
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=_CUDA_INIT_WARNING_RE,
+            category=UserWarning,
+        )
+        try:
+            return bool(torch.cuda.is_available())
+        except Exception:
+            return False
+
+
+def select_torch_device() -> torch.device:
+    """Choose CUDA when available, otherwise fall back to CPU."""
+
+    return torch.device("cuda" if cuda_is_available() else "cpu")

--- a/tests/test_cv.py
+++ b/tests/test_cv.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Iterable, List
 
 import numpy as np
@@ -123,9 +124,35 @@ def test_calculate_cv_folds_degenerates_to_kfold_when_needed(monkeypatch):
 
     monkeypatch.setattr(cv, "StratifiedKFold", FailStratified)
 
-    folds = cv.calculate_cv_folds(fake_conn, n_splits=4, random_state=0)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        folds = cv.calculate_cv_folds(fake_conn, n_splits=4, random_state=0)
 
     assert set(folds.keys()) == set(range(1, 9))
     counts = np.bincount(list(folds.values()))
     assert counts.shape[0] == 4
     assert np.all(counts == 2)
+    assert caught == []
+
+
+def test_calculate_cv_folds_can_warn_on_fallback(monkeypatch):
+    """Callers can opt into a warning when stratification is impossible."""
+
+    info_schema_rows = [("taxonomy_path",)]
+    product_rows = [
+        {"id": idx, "taxonomy_path": f"{idx}"} for idx in range(1, 9)
+    ]
+
+    fake_conn = FakeConnection(info_schema_rows, product_rows)
+
+    monkeypatch.setattr(cv, "dict_row", dict_identity)
+
+    with pytest.warns(RuntimeWarning, match="Taxonomy distribution too sparse"):
+        folds = cv.calculate_cv_folds(
+            fake_conn,
+            n_splits=4,
+            random_state=0,
+            warn_on_fallback=True,
+        )
+
+    assert set(folds.keys()) == set(range(1, 9))

--- a/tests/test_torch_runtime.py
+++ b/tests/test_torch_runtime.py
@@ -1,0 +1,27 @@
+"""Tests for torch runtime helpers."""
+
+from __future__ import annotations
+
+import warnings
+
+from padjective import torch_runtime
+
+
+def test_select_torch_device_suppresses_noisy_cuda_probe_warning(monkeypatch):
+    """CPU fallback should not leak PyTorch's CUDA probe warning."""
+
+    def fake_is_available():
+        warnings.warn(
+            "CUDA initialization: Unexpected error from cudaGetDeviceCount().",
+            UserWarning,
+        )
+        return False
+
+    monkeypatch.setattr(torch_runtime.torch.cuda, "is_available", fake_is_available)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        device = torch_runtime.select_torch_device()
+
+    assert device.type == "cpu"
+    assert caught == []


### PR DESCRIPTION
## Summary
- add a shared torch runtime helper to select CPU/GPU without surfacing noisy CUDA probe warnings
- make CV fold generation fall back to deterministic `KFold` quietly by default, with an opt-in warning path for callers that want it
- suppress expected sklearn `ConvergenceWarning` noise in benchmark and ULR training flows
- remove the deprecated `multi_class` override from benchmark logistic regression setup
- add regression coverage for silent CV fallback and quiet torch device selection

## Testing
- `uv run -m pytest -q`